### PR TITLE
Add list support to monitor display

### DIFF
--- a/source/scratch/blocks/data.cpp
+++ b/source/scratch/blocks/data.cpp
@@ -49,6 +49,30 @@ BlockResult DataBlocks::hideVariable(Block &block, Sprite *sprite, bool *without
     return BlockResult::CONTINUE;
 }
 
+
+BlockResult DataBlocks::showList(Block &block, Sprite *sprite, bool *withoutScreenRefresh, bool fromRepeat) {
+    std::string varId = block.fields["LIST"][1].get<std::string>();
+    for (Monitor &var : Render::visibleVariables) {
+        if (var.id == varId) {
+            var.visible = true;
+            break;
+        }
+    }
+
+    return BlockResult::CONTINUE;
+}
+
+BlockResult DataBlocks::hideList(Block &block, Sprite *sprite, bool *withoutScreenRefresh, bool fromRepeat) {
+    std::string varId = block.fields["LIST"][1].get<std::string>();
+    for (Monitor &var : Render::visibleVariables) {
+        if (var.id == varId) {
+            var.visible = false;
+            break;
+        }
+    }
+    return BlockResult::CONTINUE;
+}
+
 BlockResult DataBlocks::addToList(Block &block, Sprite *sprite, bool *withoutScreenRefresh, bool fromRepeat) {
     Value val = Scratch::getInputValue(block, "ITEM", sprite);
     std::string listId = block.fields.at("LIST")[1];

--- a/source/scratch/blocks/data.hpp
+++ b/source/scratch/blocks/data.hpp
@@ -7,6 +7,8 @@ class DataBlocks {
     static BlockResult changeVariable(Block &block, Sprite *sprite, bool *withoutScreenRefresh, bool fromRepeat);
     static BlockResult showVariable(Block &block, Sprite *sprite, bool *withoutScreenRefresh, bool fromRepeat);
     static BlockResult hideVariable(Block &block, Sprite *sprite, bool *withoutScreenRefresh, bool fromRepeat);
+    static BlockResult showList(Block &block, Sprite *sprite, bool *withoutScreenRefresh, bool fromRepeat);
+    static BlockResult hideList(Block &block, Sprite *sprite, bool *withoutScreenRefresh, bool fromRepeat);
     static BlockResult addToList(Block &block, Sprite *sprite, bool *withoutScreenRefresh, bool fromRepeat);
     static BlockResult deleteFromList(Block &block, Sprite *sprite, bool *withoutScreenRefresh, bool fromRepeat);
     static BlockResult deleteAllOfList(Block &block, Sprite *sprite, bool *withoutScreenRefresh, bool fromRepeat);


### PR DESCRIPTION
The changes are not very big, but with this it should also be possible to display lists.
A list is treated as a single string, using \n as a separator so that each element appears on a new line.