### PR TITLE
Add loudness variable

### DIFF
--- a/source/3ds/render.cpp
+++ b/source/3ds/render.cpp
@@ -6,6 +6,7 @@
 #include "../scratch/render.hpp"
 #include "../scratch/text.hpp"
 #include "../scratch/unzip.hpp"
+#include "mic.hpp"
 #include "image.hpp"
 #include "interpret.hpp"
 #ifdef ENABLE_AUDIO
@@ -486,6 +487,7 @@ void Render::deInit() {
 #ifdef ENABLE_AUDIO
     SDL_Quit();
 #endif
+    exitMic();
     romfsExit();
     gfxExit();
 }

--- a/source/scratch/blockExecutor.cpp
+++ b/source/scratch/blockExecutor.cpp
@@ -163,6 +163,7 @@ void BlockExecutor::registerHandlers() {
     valueHandlers["sensing_touchingobjectmenu"] = SensingBlocks::touchingObject; // Menu variant
     valueHandlers["sensing_mousedown"] = SensingBlocks::mouseDown;
     valueHandlers["sensing_username"] = SensingBlocks::username;
+    valueHandlers["sensing_loudness"] = SensingBlocks::loudness;
 
     // procedures / arguments
     handlers["procedures_call"] = ProcedureBlocks::call;

--- a/source/scratch/blocks/sensing.cpp
+++ b/source/scratch/blocks/sensing.cpp
@@ -1,6 +1,7 @@
 #include "sensing.hpp"
 #include "../input.hpp"
 #include "../keyboard.hpp"
+#include "mic.hpp"
 #include "blockExecutor.hpp"
 #include "interpret.hpp"
 #include "sprite.hpp"
@@ -188,4 +189,9 @@ Value SensingBlocks::mouseDown(Block &block, Sprite *sprite) {
 
 Value SensingBlocks::username(Block &block, Sprite *sprite) {
     return Value(Input::getUsername());
+}
+
+Value SensingBlocks::loudness(Block &block, Sprite *sprite) {
+    if(!micInitialized) initMic();
+    return Value(getMicLevel());
 }

--- a/source/scratch/blocks/sensing.hpp
+++ b/source/scratch/blocks/sensing.hpp
@@ -20,4 +20,5 @@ class SensingBlocks {
     static Value touchingObject(Block &block, Sprite *sprite);
     static Value mouseDown(Block &block, Sprite *sprite);
     static Value username(Block &block, Sprite *sprite);
+    static Value loudness(Block &block, Sprite *sprite);
 };

--- a/source/scratch/mic.cpp
+++ b/source/scratch/mic.cpp
@@ -1,0 +1,80 @@
+#ifdef __3DS__
+
+#include "mic.hpp"
+#include <stdio.h>
+#include <math.h>
+
+u8* micbuf = nullptr;
+u32 micbuf_datasize = 0;
+bool micInitialized = false;
+
+#define SAMPLE_CHUNK 128
+#define MIC_SENSITIVITY 30.0 
+
+static s16 sampleBuffer[SAMPLE_CHUNK];
+
+bool initMic() {
+    if(micInitialized) return true;
+
+    u32 micbuf_size = 0x30000;
+    micbuf = (u8*)memalign(0x1000, micbuf_size);
+    if(!micbuf) return false;
+
+    if(R_FAILED(csndInit())) return false;
+    if(R_FAILED(micInit(micbuf, micbuf_size))) return false;
+
+    micbuf_datasize = micGetSampleDataSize();
+    if(R_SUCCEEDED(MICU_StartSampling(MICU_ENCODING_PCM16_SIGNED, MICU_SAMPLE_RATE_16360, 0, micbuf_datasize, true)))
+        micInitialized = true;
+
+    return micInitialized;
+}
+
+int getMicLevel() {
+    if(!micInitialized) return 0;
+
+    u32 lastOffset = micGetLastSampleOffset();
+    u32 readPos = (lastOffset + micbuf_datasize - SAMPLE_CHUNK) % micbuf_datasize;
+    size_t count = 0;
+
+    while(count < SAMPLE_CHUNK) {
+        sampleBuffer[count] = ((s16*)micbuf)[readPos];
+        readPos = (readPos + 1) % micbuf_datasize;
+        count++;
+    }
+
+    double sum = 0.0;
+    for(size_t i = 0; i < count; i++)
+        sum += sampleBuffer[i] * sampleBuffer[i];
+
+    double rms = sqrt(sum / count);
+
+    int level = (int)((rms / 32767.0) * 100.0 * MIC_SENSITIVITY);
+    if(level > 100) level = 100;
+    return level;
+}
+
+void exitMic() {
+    if(!micInitialized) return;
+    MICU_StopSampling();
+    micExit();
+    csndExit();
+    free(micbuf);
+    micInitialized = false;
+}
+
+#else
+
+#include <stdio.h>
+
+bool initMic() { 
+    return false; 
+}
+
+int getMicLevel() { 
+    return -1; 
+}
+
+void exitMic() { }
+
+#endif

--- a/source/scratch/mic.hpp
+++ b/source/scratch/mic.hpp
@@ -1,0 +1,15 @@
+#pragma once
+#include <math.h>
+
+#ifdef __3DS__
+#include <3ds.h>
+#include <malloc.h>
+#endif
+
+extern u8* micbuf;
+extern u32 micbuf_datasize;
+extern bool micInitialized;
+
+int getMicLevel();
+bool initMic();
+void exitMic();


### PR DESCRIPTION
I added support for the loudness variable block.
It now returns a value from 0 to 100. If the device isn’t a 3DS or the mic can’t be initialized, it returns -1.

There’s a MIC_SENSITIVITY variable in mic.cpp (currently 30.0). This might still need some tweaking to get values closer to Scratch.

I’m not sure how the microphone behaves on a real 3DS, but in Citra it might react a bit differently than on real hardware (could be more or less sensitive).