### PR TITLE
[BUG] Fix title and splash text animation issues

### DIFF
--- a/source/scratch/menus/mainMenu.cpp
+++ b/source/scratch/menus/mainMenu.cpp
@@ -6,6 +6,7 @@
 #include "projectMenu.hpp"
 #include "settingsMenu.hpp"
 #include <cctype>
+#include <cmath>
 
 Menu::~Menu() = default;
 
@@ -85,7 +86,10 @@ void MainMenu::init() {
     splashText->setCenterAligned(true);
     splashText->setColor(Math::color(243, 154, 37, 255));
     if (splashText->getSize()[0] > logo->image->getWidth() * 0.95) {
-        splashText->scale = (float)logo->image->getWidth() / (splashText->getSize()[0] * 1.15);
+        splashTextOriginalScale = (float)logo->image->getWidth() / (splashText->getSize()[0] * 1.15);
+        splashText->scale = splashTextOriginalScale;
+    } else {
+        splashTextOriginalScale = splashText->scale;
     }
 
     loadButton = new ButtonObject("", "gfx/menu/play.svg", 100, 180, "gfx/menu/Ubuntu-Bold");
@@ -117,9 +121,10 @@ void MainMenu::render() {
 
     // move and render logo
     const float elapsed = logoStartTime.getTimeMs();
-    float bobbingOffset = std::sin(elapsed * 0.0025f) * 5.0f;
-    float splashZoom = std::sin(elapsed * 0.0085f) * 0.005f;
-    splashText->scale += splashZoom;
+    // fmod to prevent precision issues with large elapsed times
+    float bobbingOffset = std::sin(std::fmod(elapsed * 0.0025f, 2.0f * M_PI)) * 5.0f;
+    float splashZoom = std::sin(std::fmod(elapsed * 0.0085f, 2.0f * M_PI)) * 0.05f;
+    splashText->scale = splashTextOriginalScale + splashZoom;
     logo->y = 75 + bobbingOffset;
     logo->render();
     versionNumber->render(Render::getWidth() * 0.01, Render::getHeight() * 0.935);

--- a/source/scratch/menus/mainMenu.hpp
+++ b/source/scratch/menus/mainMenu.hpp
@@ -45,6 +45,7 @@ class MainMenu : public Menu {
     ControlObject *mainMenuControl = nullptr;
     TextObject *versionNumber = nullptr;
     TextObject *splashText = nullptr;
+    float splashTextOriginalScale = 1.0f;
 
     int selectedTextIndex = 0;
 


### PR DESCRIPTION
Fixes issue #397 

## Description of issue
If you leave the main menu running for several minutes, the splash text gradually gets larger and larger. I assume it's related to the zoom in / zoom out animation.

I noticed this when I accidentally left the project running in the main menu in the background, and when I found it, the splash text was huge.

## Changes made
Fixed splash text size issue by adding splashZoom (samples the sine wave to determine text size) to the **original** splash size (stored in new var "splashTextOriginalScale" that gets set on init) to avoid tiny floating-point errors accumulating in the scale. Essentially, setting the splashText->scale to 1 + sine wave, instead of sampling the sine wave and adding that directly to splashText->scale.

While testing this, I also noticed that the bobbing effect starts twitching and skipping frames when the main menu has been open for a while. I found that this was due to precision issues when the elapsed time being used for the animation grew too large, so I fixed that in this PR as well.

## Testing
To test this, I left the dolphin-emu emulator running in the background for half an hour or so while doing other tasks, which is how I recreated the issue in #397. This time, when I came back, the text was the correct size.