### PR TITLE
[GameCube] Migrate to libogc2

### DIFF
--- a/docker/Dockerfile.gamecube
+++ b/docker/Dockerfile.gamecube
@@ -1,11 +1,11 @@
-FROM devkitpro/devkitppc:latest AS libromfs_builder
+FROM ghcr.io/extremscorner/libogc2:latest AS libromfs_builder
 WORKDIR /libromfs
 
 RUN git clone https://github.com/NateXS/libromfs-ogc.git . 
 RUN make PLATFORM=gamecube
 RUN make install PLATFORM=gamecube
 
-FROM devkitpro/devkitppc:latest AS main_builder
+FROM ghcr.io/extremscorner/libogc2:latest AS main_builder
 WORKDIR /app
 
 COPY --from=libromfs_builder /opt/devkitpro/portlibs/gamecube/ /opt/devkitpro/portlibs/gamecube/

--- a/gfx/menu/splashText.txt
+++ b/gfx/menu/splashText.txt
@@ -31,7 +31,7 @@ Formerly Scratch-3DS!
 Runtime by NateXS!
 3DS port by NateXS!
 Wii port by NateXS!
-Gamecube port by NateXS!
+GameCube port by NateXS!
 By NateXS and Grady Link!
 Wii U port by Grady Link!
 Switch port by Grady Link!

--- a/make/Makefile_gamecube
+++ b/make/Makefile_gamecube
@@ -9,9 +9,9 @@ $(error "Please set DEVKITPPC in your environment. export DEVKITPPC=<path to>dev
 endif
 
 TOPDIR ?= $(CURDIR)
-include $(DEVKITPPC)/gamecube_rules
+include $(DEVKITPRO)/libogc2/gamecube_rules
 
-PKGCONF_GAMECUBE	:=	$(DEVKITPRO)/portlibs/gamecube/bin/powerpc-eabi-pkg-config
+PKGCONF_GAMECUBE	:=	$(DEVKITPRO)/libogc2/gamecube/bin/powerpc-eabi-pkg-config
 
 #---------------------------------------------------------------------------------
 # Application info

--- a/source/scratch/menus/projectMenu.cpp
+++ b/source/scratch/menus/projectMenu.cpp
@@ -81,7 +81,7 @@ void ProjectMenu::init() {
 #elif defined(VITA)
         noProjectInfo->setText("Put Scratch projects in ux0:data/scratch-vita/ !");
 #elif defined(GAMECUBE)
-        noProjectInfo->setText("Put Scratch projects in SD Card A:/scratch-gamecube/ !");
+        noProjectInfo->setText("Put Scratch projects in sd:/scratch-gamecube/ !");
 #elif defined(__SWITCH__)
         noProjectInfo->setText("Put Scratch projects in sd:/switch/scratch-nx !");
 #else

--- a/source/scratch/os.cpp
+++ b/source/scratch/os.cpp
@@ -6,9 +6,6 @@
 #include <iostream>
 #include <ostream>
 #include <string>
-#ifdef __OGC__
-#include <gccore.h>
-#endif
 #ifdef __WIIU__
 #include <sstream>
 #include <whb/sdcard.h>
@@ -50,24 +47,6 @@ void Log::writeToFile(std::string message) {
     }
 }
 
-// Wii and Gamecube Timer implementation
-#ifdef __OGC__
-
-Timer::Timer() {
-    start();
-}
-
-void Timer::start() {
-    startTime = gettick();
-}
-
-int Timer::getTimeMs() {
-    u64 currentTime = gettick();
-    return ticks_to_millisecs(currentTime - startTime);
-}
-
-// everyone else...
-#else
 Timer::Timer() {
     start();
 }
@@ -81,8 +60,6 @@ int Timer::getTimeMs() {
     auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(currentTime - startTime);
     return static_cast<int>(duration.count());
 }
-
-#endif
 
 bool Timer::hasElapsed(int milliseconds) {
     return getTimeMs() >= milliseconds;
@@ -104,7 +81,7 @@ std::string OS::getScratchFolderLocation() {
 #elif defined(WII)
     return "/apps/scratch-wii/";
 #elif defined(GAMECUBE)
-    return "carda:/scratch-gamecube/";
+    return "/scratch-gamecube/";
 #elif defined(VITA)
     return "ux0:data/scratch-vita/";
 #elif defined(__3DS__)

--- a/source/scratch/os.hpp
+++ b/source/scratch/os.hpp
@@ -3,10 +3,6 @@
 #ifdef __3DS__
 #include <3ds.h>
 #endif
-#ifdef __OGC__
-#include <ogc/lwp_watchdog.h>
-#include <ogc/system.h>
-#endif
 #pragma once
 
 class MemoryTracker {
@@ -164,11 +160,7 @@ void writeToFile(std::string message);
 
 class Timer {
   private:
-#ifdef __OGC__
-    u64 startTime;
-#else
     std::chrono::high_resolution_clock::time_point startTime;
-#endif
 
   public:
     Timer();

--- a/source/scratch/render.hpp
+++ b/source/scratch/render.hpp
@@ -5,11 +5,6 @@
 #include <chrono>
 #include <vector>
 
-#ifdef __OGC__
-#include <ogc/lwp_watchdog.h>
-#include <ogc/system.h>
-#endif
-
 class Render {
   public:
     static std::chrono::system_clock::time_point startTime;

--- a/source/scratch/unzip.hpp
+++ b/source/scratch/unzip.hpp
@@ -4,12 +4,6 @@
 #include <filesystem>
 #include <fstream>
 #include <random>
-#ifdef GAMECUBE
-#include <dirent.h>
-#include <gccore.h>
-#include <sys/stat.h>
-#include <sys/types.h>
-#endif
 
 #ifdef ENABLE_CLOUDVARS
 extern std::string projectJSON;
@@ -60,26 +54,6 @@ class Unzip {
         return;
     }
 
-#ifdef GAMECUBE
-    // use libogc for gamecube because i guess it doesn't support std::filesystem
-    static std::vector<std::string> getProjectFiles(const std::string &directory) {
-        std::vector<std::string> projectFiles;
-        DIR *dir = opendir(directory.c_str());
-        if (dir == nullptr) {
-            return projectFiles;
-        }
-
-        struct dirent *entry;
-        while ((entry = readdir(dir)) != nullptr) {
-            std::string fileName = entry->d_name;
-            if (fileName.length() > 4 && fileName.substr(fileName.length() - 4) == ".sb3") {
-                projectFiles.push_back(fileName);
-            }
-        }
-        closedir(dir);
-        return projectFiles;
-    }
-#else
     static std::vector<std::string> getProjectFiles(const std::string &directory) {
         std::vector<std::string> projectFiles;
 
@@ -109,7 +83,6 @@ class Unzip {
 
         return projectFiles;
     }
-#endif
 
     static std::string getSplashText() {
         std::string textPath = "gfx/menu/splashText.txt";
@@ -253,14 +226,9 @@ class Unzip {
             if (filename.find('/') != std::string::npos || filename.find('\\') != std::string::npos)
                 continue;
 
-#ifdef GAMECUBE
-            mkdir(destFolder.c_str(), 0777);
-#endif
             std::string outPath = destFolder + "/" + filename;
 
-#ifndef GAMECUBE
             std::filesystem::create_directories(std::filesystem::path(outPath).parent_path());
-#endif
 
             if (!mz_zip_reader_extract_to_file(&zip, i, outPath.c_str(), 0)) {
                 Log::logError("Failed to extract: " + outPath);

--- a/source/sdl/input.cpp
+++ b/source/sdl/input.cpp
@@ -23,7 +23,6 @@ extern char nickname[0x21];
 #endif
 
 #ifdef WII
-#include <gccore.h>
 #include <ogc/conf.h>
 #endif
 
@@ -157,7 +156,7 @@ void Input::getInput() {
     if (SDL_GameControllerGetButton(controller, SDL_GameControllerButton::SDL_CONTROLLER_BUTTON_X)) {
         Input::buttonPress("X");
         anyKeyPressed = true;
-#ifdef __OGC__ // SDL 'x' is the A button on a wii remote
+#ifdef WII // SDL 'x' is the A button on a wii remote
         mousePointer.isPressed = true;
 #endif
     }

--- a/source/sdl/render.cpp
+++ b/source/sdl/render.cpp
@@ -39,11 +39,13 @@ char nickname[0x21];
 
 #ifdef __OGC__
 #include <fat.h>
+#include <ogc/system.h>
 #include <romfs-ogc.h>
 #endif
 
 #ifdef GAMECUBE
-#include <sdcard/gcsd.h>
+#include <ogc/consol.h>
+#include <ogc/exi.h>
 #endif
 
 int windowWidth = 540;
@@ -131,7 +133,14 @@ bool Render::Init() {
     accountExit();
 postAccount:
 #elif defined(__OGC__)
+#ifdef GAMECUBE
+    if ((SYS_GetConsoleType() & SYS_CONSOLE_MASK) == SYS_CONSOLE_DEVELOPMENT) {
+        CON_EnableBarnacle(EXI_CHANNEL_0, EXI_DEVICE_1);
+    }
+    CON_EnableGecko(EXI_CHANNEL_1, true);
+#else
     SYS_STDIO_Report(true);
+#endif
 
     fatInitDefault();
     windowWidth = 640;
@@ -140,11 +149,6 @@ postAccount:
         Log::logError("Failed to init romfs.");
         return false;
     }
-
-#ifdef GAMECUBE
-    if (!fatMountSimple("carda", &__io_gcsda))
-        Log::logError("Failed to initialize SD card.");
-#endif
 
 #elif defined(VITA)
     SDL_setenv("VITA_DISABLE_TOUCH_BACK", "1", 1);


### PR DESCRIPTION
This adds support for the following:
- exFAT filesystem
- CUBEODE and GC Loader
- Semi-passive SD card adapters (GC2SD Gen2, SD2SP2 2.0, etc.)
- Combo SD card adapters (ETH2GC Sidecar+ and Netcard+)
- SD2SP1
- Expanded MRAM in Dolphin, Orca boards and TDEV
- Possibly more, I forget

This fixes the following:
- #239
- Inputs getting stuck due to `SDL_PrivateJoystickAxis` clamping the analog triggers to a minimum value of 16383
- System time getting reset to January 1st, 2000 due to `SYS_STDIO_Report`
- Progressive scan mode being forcibly enabled when using component video
- Possibly more, I forget

Some common code was also cleaned up. libogc finally supports `std::chrono` since 2.12.0.