### PR TITLE
Fix direction clamping and rounding

### DIFF
--- a/source/scratch/blocks/motion.cpp
+++ b/source/scratch/blocks/motion.cpp
@@ -82,25 +82,31 @@ BlockResult MotionBlocks::goToXY(Block &block, Sprite *sprite, bool *withoutScre
 
 BlockResult MotionBlocks::turnLeft(Block &block, Sprite *sprite, bool *withoutScreenRefresh, bool fromRepeat) {
     Value value = Scratch::getInputValue(block, "DEGREES", sprite);
-    if (value.isNumeric()) {
-        sprite->rotation -= value.asDouble();
+    const double direction = value.asDouble();
+    if (direction == std::numeric_limits<double>::infinity() || direction == -std::numeric_limits<double>::infinity()) {
+        return BlockResult::CONTINUE;
     }
+    sprite->rotation -= direction - floor((direction + 179) / 360) * 360;
     return BlockResult::CONTINUE;
 }
 
 BlockResult MotionBlocks::turnRight(Block &block, Sprite *sprite, bool *withoutScreenRefresh, bool fromRepeat) {
     Value value = Scratch::getInputValue(block, "DEGREES", sprite);
-    if (value.isNumeric()) {
-        sprite->rotation += value.asDouble();
+    const double direction = value.asDouble();
+    if (direction == std::numeric_limits<double>::infinity() || direction == -std::numeric_limits<double>::infinity()) {
+        return BlockResult::CONTINUE;
     }
+    sprite->rotation += direction - floor((direction + 179) / 360) * 360;
     return BlockResult::CONTINUE;
 }
 
 BlockResult MotionBlocks::pointInDirection(Block &block, Sprite *sprite, bool *withoutScreenRefresh, bool fromRepeat) {
     Value value = Scratch::getInputValue(block, "DIRECTION", sprite);
-    if (value.isNumeric()) {
-        sprite->rotation = value.asDouble();
+    const double direction = value.asDouble();
+    if (direction == std::numeric_limits<double>::infinity() || direction == -std::numeric_limits<double>::infinity()) {
+        return BlockResult::CONTINUE;
     }
+    sprite->rotation = direction - floor((direction + 179) / 360) * 360;
     return BlockResult::CONTINUE;
 }
 


### PR DESCRIPTION
There was no clamping for the direction reporter, so the block could have a direction that was way larger than normal.

Test cases: [Project.zip](https://github.com/user-attachments/files/23323071/Project.zip)