### PR TITLE
Fix change block when adding non-numerical value

### DIFF
--- a/source/scratch/blocks/data.cpp
+++ b/source/scratch/blocks/data.cpp
@@ -21,11 +21,7 @@ BlockResult DataBlocks::changeVariable(Block &block, Sprite *sprite, bool *witho
     std::string varId = Scratch::getFieldId(block, "VARIABLE");
     Value oldVariable = BlockExecutor::getVariableValue(varId, sprite);
 
-    if (val.isNumeric() && oldVariable.isNumeric()) {
-        val = val + oldVariable;
-    }
-
-    BlockExecutor::setVariableValue(varId, val, sprite);
+    BlockExecutor::setVariableValue(varId, Value(val.asDouble() + oldVariable.asDouble()), sprite);
     return BlockResult::CONTINUE;
 }
 


### PR DESCRIPTION
Previously, when you changed a variable by a string, it would set the variable to that string instead of keeping the value intact.