### PR TITLE
Fix max pen size and int conversion

### DIFF
--- a/source/3ds/render.cpp
+++ b/source/3ds/render.cpp
@@ -154,7 +154,7 @@ void Render::penMove(double x1, double y1, double x2, double y2, Sprite *sprite)
     const float heightMultiplier = 0.5f;
     const int transparency = 255 * (1 - sprite->penData.transparency / 100);
     const u32 color = C2D_Color32(rgbColor.r, rgbColor.g, rgbColor.b, transparency);
-    const int thickness = std::clamp(static_cast<int>(sprite->penData.size * renderScale), 1, 1000);
+    const float thickness = sprite->penData.size * renderScale;
 
     const float x1_scaled = (x1 * renderScale) + (width / 2);
     const float y1_scaled = (y1 * -1 * renderScale) + (height * heightMultiplier) + TEXTURE_OFFSET;

--- a/source/scratch/blocks/pen.cpp
+++ b/source/scratch/blocks/pen.cpp
@@ -24,7 +24,7 @@ SDL_Texture *penTexture;
 #endif
 
 const unsigned int minPenSize = 1;
-const unsigned int maxPenSize = 1000;
+const unsigned int maxPenSize = 1200;
 
 BlockResult PenBlocks::PenDown(Block &block, Sprite *sprite, bool *withoutScreenRefresh, bool fromRepeat) {
     if (!Render::initPen()) return BlockResult::CONTINUE;


### PR DESCRIPTION
The max pen size in Scratch is 1200, not 1000. Also, today I learned that Scratch supports decimal pen sizes.