### PR TITLE
[SDL2] Specify project loader thread's stack size

### DIFF
--- a/source/scratch/unzip.cpp
+++ b/source/scratch/unzip.cpp
@@ -169,7 +169,7 @@ bool Unzip::load() {
 
 #elif defined(SDL_BUILD) // create SDL2 thread for loading screen
 
-    SDL_Thread *thread = SDL_CreateThread(projectLoaderThread, "LoadingScreen", nullptr);
+    SDL_Thread *thread = SDL_CreateThreadWithStackSize(projectLoaderThread, "LoadingScreen", 0x4000, nullptr);
 
     if (thread != NULL && thread != nullptr) {
 


### PR DESCRIPTION
This fixes a stack overflow on GameCube caught by https://github.com/extremscorner/libogc2/commit/e6b76febf47a28beb18391f46c415956f99266bb.

The Wii is also affected, but libogc's SDL2 port lacks the necessary plumbing for this change to have any effect. The issue is also silent there.