### PR TITLE
[Runtime] Preserve project order for sounds and block chains

### DIFF
--- a/source/scratch/blockExecutor.cpp
+++ b/source/scratch/blockExecutor.cpp
@@ -392,10 +392,15 @@ void BlockExecutor::runRepeatBlocks() {
     // repeat ONLY the block most recently added to the repeat chain,,,
     std::vector<Sprite *> sprToRun = sprites;
     for (auto &sprite : sprToRun) {
-        for (const std::string &chainId : sprite->blockChainOrder) {
-            auto it = sprite->blockChains.find(chainId);
-            if (it == sprite->blockChains.end()) continue;
-            auto &blockChain = it->second;
+        // Collect and sort blockChains by insertionOrder
+        std::vector<std::pair<size_t, std::string>> orderedChains;
+        for (const auto &[chainId, chain] : sprite->blockChains) {
+            orderedChains.emplace_back(chain.insertionOrder, chainId);
+        }
+        std::sort(orderedChains.begin(), orderedChains.end());
+
+        for (const auto &[order, chainId] : orderedChains) {
+            auto &blockChain = sprite->blockChains[chainId];
             auto &repeatList = blockChain.blocksToRepeat;
             if (!repeatList.empty()) {
                 std::string toRepeat = repeatList.back();

--- a/source/scratch/blockExecutor.cpp
+++ b/source/scratch/blockExecutor.cpp
@@ -392,7 +392,10 @@ void BlockExecutor::runRepeatBlocks() {
     // repeat ONLY the block most recently added to the repeat chain,,,
     std::vector<Sprite *> sprToRun = sprites;
     for (auto &sprite : sprToRun) {
-        for (auto &[id, blockChain] : sprite->blockChains) {
+        for (const std::string &chainId : sprite->blockChainOrder) {
+            auto it = sprite->blockChains.find(chainId);
+            if (it == sprite->blockChains.end()) continue;
+            auto &blockChain = it->second;
             auto &repeatList = blockChain.blocksToRepeat;
             if (!repeatList.empty()) {
                 std::string toRepeat = repeatList.back();
@@ -680,13 +683,13 @@ void BlockExecutor::updateMonitors() {
                     else if (var.opcode == "sensing_current")
                         var.displayName = std::string(MonitorDisplayNames::getCurrentMenuMonitorName(Scratch::getFieldValue(newBlock, "CURRENTMENU")));
                     else {
-                    	auto spriteName = MonitorDisplayNames::getSpriteMonitorName(var.opcode);
-                    	if (spriteName != var.opcode) {
-                    	    var.displayName = var.spriteName + ": " + std::string(spriteName);
-                    	} else {
-                    	    auto simpleName = MonitorDisplayNames::getSimpleMonitorName(var.opcode);
-                    	    var.displayName = simpleName != var.opcode ? std::string(simpleName) : var.opcode;
-                    	}
+                        auto spriteName = MonitorDisplayNames::getSpriteMonitorName(var.opcode);
+                        if (spriteName != var.opcode) {
+                            var.displayName = var.spriteName + ": " + std::string(spriteName);
+                        } else {
+                            auto simpleName = MonitorDisplayNames::getSimpleMonitorName(var.opcode);
+                            var.displayName = simpleName != var.opcode ? std::string(simpleName) : var.opcode;
+                        }
                     }
                     var.value = executor.getBlockValue(newBlock, sprite);
                 } catch (...) {

--- a/source/scratch/blocks/sound.cpp
+++ b/source/scratch/blocks/sound.cpp
@@ -30,12 +30,13 @@ BlockResult SoundBlocks::playSoundUntilDone(Block &block, Sprite *sprite, bool *
         // If not found by name and input is a number, try index-based lookup
         if (!soundFound && Math::isNumber(inputValue.asString())) {
             int soundIndex = inputValue.asInt() - 1;
-            if (soundIndex >= 0 && static_cast<size_t>(soundIndex) < sprite->soundOrder.size()) {
-                const std::string &soundName = sprite->soundOrder[soundIndex];
-                auto it = sprite->sounds.find(soundName);
-                if (it != sprite->sounds.end()) {
-                    soundFullName = it->second.fullName;
-                    soundFound = true;
+            if (soundIndex >= 0 && static_cast<size_t>(soundIndex) < sprite->sounds.size()) {
+                for (const auto &[name, sound] : sprite->sounds) {
+                    if (sound.insertionOrder == static_cast<size_t>(soundIndex)) {
+                        soundFullName = sound.fullName;
+                        soundFound = true;
+                        break;
+                    }
                 }
             }
         }
@@ -57,11 +58,12 @@ BlockResult SoundBlocks::playSoundUntilDone(Block &block, Sprite *sprite, bool *
         checkSoundName = soundFind->second.fullName;
     } else if (Math::isNumber(inputValue.asString())) {
         int soundIndex = inputValue.asInt() - 1;
-        if (soundIndex >= 0 && static_cast<size_t>(soundIndex) < sprite->soundOrder.size()) {
-            const std::string &soundName = sprite->soundOrder[soundIndex];
-            auto it = sprite->sounds.find(soundName);
-            if (it != sprite->sounds.end()) {
-                checkSoundName = it->second.fullName;
+        if (soundIndex >= 0 && static_cast<size_t>(soundIndex) < sprite->sounds.size()) {
+            for (const auto &[name, sound] : sprite->sounds) {
+                if (sound.insertionOrder == static_cast<size_t>(soundIndex)) {
+                    checkSoundName = sound.fullName;
+                    break;
+                }
             }
         }
     }
@@ -90,12 +92,13 @@ BlockResult SoundBlocks::playSound(Block &block, Sprite *sprite, bool *withoutSc
     // If not found by name and input is a number, try index-based lookup
     if (!soundFound && Math::isNumber(inputValue.asString())) {
         int soundIndex = inputValue.asInt() - 1;
-        if (soundIndex >= 0 && static_cast<size_t>(soundIndex) < sprite->soundOrder.size()) {
-            const std::string &soundName = sprite->soundOrder[soundIndex];
-            auto it = sprite->sounds.find(soundName);
-            if (it != sprite->sounds.end()) {
-                soundFullName = it->second.fullName;
-                soundFound = true;
+        if (soundIndex >= 0 && static_cast<size_t>(soundIndex) < sprite->sounds.size()) {
+            for (const auto &[name, sound] : sprite->sounds) {
+                if (sound.insertionOrder == static_cast<size_t>(soundIndex)) {
+                    soundFullName = sound.fullName;
+                    soundFound = true;
+                    break;
+                }
             }
         }
     }

--- a/source/scratch/blocks/sound.cpp
+++ b/source/scratch/blocks/sound.cpp
@@ -30,11 +30,13 @@ BlockResult SoundBlocks::playSoundUntilDone(Block &block, Sprite *sprite, bool *
         // If not found by name and input is a number, try index-based lookup
         if (!soundFound && Math::isNumber(inputValue.asString())) {
             int soundIndex = inputValue.asInt() - 1;
-            if (soundIndex >= 0 && static_cast<size_t>(soundIndex) < sprite->sounds.size()) {
-                auto it = sprite->sounds.begin();
-                std::advance(it, soundIndex);
-                soundFullName = it->second.fullName;
-                soundFound = true;
+            if (soundIndex >= 0 && static_cast<size_t>(soundIndex) < sprite->soundOrder.size()) {
+                const std::string &soundName = sprite->soundOrder[soundIndex];
+                auto it = sprite->sounds.find(soundName);
+                if (it != sprite->sounds.end()) {
+                    soundFullName = it->second.fullName;
+                    soundFound = true;
+                }
             }
         }
 
@@ -55,10 +57,12 @@ BlockResult SoundBlocks::playSoundUntilDone(Block &block, Sprite *sprite, bool *
         checkSoundName = soundFind->second.fullName;
     } else if (Math::isNumber(inputValue.asString())) {
         int soundIndex = inputValue.asInt() - 1;
-        if (soundIndex >= 0 && static_cast<size_t>(soundIndex) < sprite->sounds.size()) {
-            auto it = sprite->sounds.begin();
-            std::advance(it, soundIndex);
-            checkSoundName = it->second.fullName;
+        if (soundIndex >= 0 && static_cast<size_t>(soundIndex) < sprite->soundOrder.size()) {
+            const std::string &soundName = sprite->soundOrder[soundIndex];
+            auto it = sprite->sounds.find(soundName);
+            if (it != sprite->sounds.end()) {
+                checkSoundName = it->second.fullName;
+            }
         }
     }
 
@@ -86,11 +90,13 @@ BlockResult SoundBlocks::playSound(Block &block, Sprite *sprite, bool *withoutSc
     // If not found by name and input is a number, try index-based lookup
     if (!soundFound && Math::isNumber(inputValue.asString())) {
         int soundIndex = inputValue.asInt() - 1;
-        if (soundIndex >= 0 && static_cast<size_t>(soundIndex) < sprite->sounds.size()) {
-            auto it = sprite->sounds.begin();
-            std::advance(it, soundIndex);
-            soundFullName = it->second.fullName;
-            soundFound = true;
+        if (soundIndex >= 0 && static_cast<size_t>(soundIndex) < sprite->soundOrder.size()) {
+            const std::string &soundName = sprite->soundOrder[soundIndex];
+            auto it = sprite->sounds.find(soundName);
+            if (it != sprite->sounds.end()) {
+                soundFullName = it->second.fullName;
+                soundFound = true;
+            }
         }
     }
 

--- a/source/scratch/interpret.cpp
+++ b/source/scratch/interpret.cpp
@@ -821,8 +821,8 @@ void loadSprites(const nlohmann::json &json) {
             newSound.dataFormat = data["dataFormat"];
             newSound.sampleRate = data["rate"];
             newSound.sampleCount = data["sampleCount"];
+            newSound.insertionOrder = newSprite->sounds.size();
             newSprite->sounds[newSound.name] = newSound;
-            newSprite->soundOrder.emplace_back(newSound.name);
         }
 
         // set Costumes
@@ -1118,8 +1118,8 @@ void loadSprites(const nlohmann::json &json) {
             std::string outID;
             BlockChain chain;
             chain.blockChain = getBlockChain(block.id, &outID);
+            chain.insertionOrder = currentSprite->blockChains.size();
             currentSprite->blockChains[outID] = chain;
-            currentSprite->blockChainOrder.emplace_back(outID);
             block.blockChainID = outID;
 
             for (auto &chainBlock : chain.blockChain) {

--- a/source/scratch/interpret.cpp
+++ b/source/scratch/interpret.cpp
@@ -822,6 +822,7 @@ void loadSprites(const nlohmann::json &json) {
             newSound.sampleRate = data["rate"];
             newSound.sampleCount = data["sampleCount"];
             newSprite->sounds[newSound.name] = newSound;
+            newSprite->soundOrder.push_back(newSound.name);
         }
 
         // set Costumes
@@ -1118,7 +1119,7 @@ void loadSprites(const nlohmann::json &json) {
             BlockChain chain;
             chain.blockChain = getBlockChain(block.id, &outID);
             currentSprite->blockChains[outID] = chain;
-            // std::cout << "ok = " << outID << std::endl;
+            currentSprite->blockChainOrder.push_back(outID);
             block.blockChainID = outID;
 
             for (auto &chainBlock : chain.blockChain) {

--- a/source/scratch/interpret.cpp
+++ b/source/scratch/interpret.cpp
@@ -822,7 +822,7 @@ void loadSprites(const nlohmann::json &json) {
             newSound.sampleRate = data["rate"];
             newSound.sampleCount = data["sampleCount"];
             newSprite->sounds[newSound.name] = newSound;
-            newSprite->soundOrder.push_back(newSound.name);
+            newSprite->soundOrder.emplace_back(newSound.name);
         }
 
         // set Costumes
@@ -1119,7 +1119,7 @@ void loadSprites(const nlohmann::json &json) {
             BlockChain chain;
             chain.blockChain = getBlockChain(block.id, &outID);
             currentSprite->blockChains[outID] = chain;
-            currentSprite->blockChainOrder.push_back(outID);
+            currentSprite->blockChainOrder.emplace_back(outID);
             block.blockChainID = outID;
 
             for (auto &chainBlock : chain.blockChain) {

--- a/source/scratch/sprite.hpp
+++ b/source/scratch/sprite.hpp
@@ -105,6 +105,7 @@ struct Sound {
     std::string fullName;
     int sampleRate;
     int sampleCount;
+    size_t insertionOrder;
 };
 
 struct Costume {
@@ -137,6 +138,7 @@ struct Broadcast {
 struct BlockChain {
     std::vector<Block *> blockChain;
     std::vector<std::string> blocksToRepeat;
+    size_t insertionOrder;
 };
 
 struct Monitor {
@@ -209,13 +211,11 @@ class Sprite {
     std::map<std::string, Block> blocks;
     std::unordered_map<std::string, List> lists;
     std::map<std::string, Sound> sounds;
-    std::vector<std::string> soundOrder; // Preserves project order for index-based lookup
     std::vector<Costume> costumes;
     std::unordered_map<std::string, Comment> comments;
     std::unordered_map<std::string, Broadcast> broadcasts;
     std::unordered_map<std::string, CustomBlock> customBlocks;
     std::unordered_map<std::string, BlockChain> blockChains;
-    std::vector<std::string> blockChainOrder; // Preserves project order for deterministic execution
 
     ~Sprite() {
         variables.clear();

--- a/source/scratch/sprite.hpp
+++ b/source/scratch/sprite.hpp
@@ -209,11 +209,13 @@ class Sprite {
     std::map<std::string, Block> blocks;
     std::unordered_map<std::string, List> lists;
     std::map<std::string, Sound> sounds;
+    std::vector<std::string> soundOrder; // Preserves project order for index-based lookup
     std::vector<Costume> costumes;
     std::unordered_map<std::string, Comment> comments;
     std::unordered_map<std::string, Broadcast> broadcasts;
     std::unordered_map<std::string, CustomBlock> customBlocks;
     std::unordered_map<std::string, BlockChain> blockChains;
+    std::vector<std::string> blockChainOrder; // Preserves project order for deterministic execution
 
     ~Sprite() {
         variables.clear();


### PR DESCRIPTION
- Add soundOrder vector for index-based sound lookup
- Add blockChainOrder vector for deterministic script execution

std::map iterates alphabetically, unordered_map is non-deterministic. Caused wrong sounds on index lookup and script execution order varying per launch (flickering sprites for `forever` loops in the case of the project I was testing)

Repro: https://turbowarp.org/258765038 (flickering)