### PR TITLE
feat(openProjectBlocks): Open project in romFS

### DIFF
--- a/source/scratch/blockExecutor.cpp
+++ b/source/scratch/blockExecutor.cpp
@@ -469,6 +469,9 @@ BlockResult BlockExecutor::runCustomBlock(Sprite *sprite, Block &block, Block *c
         if (Unzip::filePath.rfind("sd:", 0) == 0) {
             std::string drivePrefix = OS::getFilesystemRootPrefix();
             Unzip::filePath.replace(0, 3, drivePrefix);
+        } else if (Unzip::filePath.rfind("romfs:", 0) == 0) {
+            std::string drivePrefix = OS::getRomFSLocation();
+            Unzip::filePath.replace(0, 6, drivePrefix);
         } else {
             Unzip::filePath = Unzip::filePath;
         }
@@ -491,6 +494,9 @@ BlockResult BlockExecutor::runCustomBlock(Sprite *sprite, Block &block, Block *c
         if (Unzip::filePath.rfind("sd:", 0) == 0) {
             std::string drivePrefix = OS::getFilesystemRootPrefix();
             Unzip::filePath.replace(0, 3, drivePrefix);
+        } else if (Unzip::filePath.rfind("romfs:", 0) == 0) {
+            std::string drivePrefix = OS::getRomFSLocation();
+            Unzip::filePath.replace(0, 6, drivePrefix);
         } else {
             Unzip::filePath = Unzip::filePath;
         }


### PR DESCRIPTION
Simple small change.
Next to the "sd:" keyword to access the internal memory 
there is now also the "romfs:" keyword

Because of this conversation:
https://discordapp.com/channels/1408875318248345612/1450739413045874698/1450739413045874698