### PR TITLE
Use custom username if setting enabled

### DIFF
--- a/source/os.cpp
+++ b/source/os.cpp
@@ -287,6 +287,18 @@ void OS::deInitWifi() {
 }
 
 std::string OS::getUsername() {
+    // use custom username if enabled in settings
+    nlohmann::json json = SettingsManager::getConfigSettings();
+    if (json.contains("EnableUsername") && json["EnableUsername"].is_boolean() && json["EnableUsername"].get<bool>()) {
+        if (json.contains("Username") && json["Username"].is_string()) {
+            std::string customUsername = json["Username"].get<std::string>();
+            if (!customUsername.empty()) {
+                return customUsername;
+            }
+        }
+    }
+
+    // otherwise, use system fallbacks
 #ifdef __WIIU__
     int16_t miiName[256];
     nn::act::GetMiiName(miiName);


### PR DESCRIPTION
I'm unsure if this was an oversight during the getUsername refactor today, but this is how I assume custom usernames are supposed to work. This simply checks if a custom username is enabled in settings and uses it if it is. If not, it falls back to the platform-specific defaults (e.g. Mii name for the Wii), and if there's not one in place, it defaults to "Player".

### Testing
Tested on PC (SDL2), NDS, 3DS and Wii. I have not tested SDL1 or SDL3, though I don't see any reason they would behave any differently.

With a custom username enabled:
<img width="545" height="444" alt="Screenshot From 2025-12-28 19-30-27" src="https://github.com/user-attachments/assets/80ff10c4-5c9c-4f45-8656-c0324a372802" />
<img width="756" height="520" alt="Screenshot From 2025-12-28 19-35-52" src="https://github.com/user-attachments/assets/df11dc40-3951-4185-abbb-f86514465fa9" />
<img width="487" height="418" alt="Screenshot From 2025-12-28 19-42-47" src="https://github.com/user-attachments/assets/7e7cbbdb-2bed-45b3-aeec-0ea83f17be0f" />
<img width="487" height="418" alt="image" src="https://github.com/user-attachments/assets/da97b6cf-6165-48b0-9daf-b7bf6705f126" />

Without custom username enabled:
<img width="545" height="444" alt="Screenshot From 2025-12-28 18-22-26" src="https://github.com/user-attachments/assets/7cabd651-89b4-4e10-98f9-d88c204609e4" />
<img width="756" height="520" alt="Screenshot From 2025-12-28 19-36-10" src="https://github.com/user-attachments/assets/56a0fed2-8477-4ab6-ac12-3a733e6f0c56" />
<img width="487" height="418" alt="Screenshot From 2025-12-28 19-43-21" src="https://github.com/user-attachments/assets/04feddce-d4aa-4447-ae30-daa0f49766f8" />
<img width="487" height="418" alt="image" src="https://github.com/user-attachments/assets/9cddfd60-da1f-46e0-b784-cf6032eebc2b" />
