### PR TITLE
Support undefined

### DIFF
--- a/source/render.hpp
+++ b/source/render.hpp
@@ -195,6 +195,30 @@ class Render {
     }
 
     /**
+     * Gets a variable value as a string for display
+     */
+    static std::string getVariableValueString(Value value) {
+        if (value.isDouble()) {
+            return Math::toString(std::round(value.asDouble() * 1e6) / 1e6); // js Number(value.toFixed(6))
+        } else if (value.isUndefined()) {
+            return ""; // Scratch keeps the original value, leave blank for now
+        } else {
+            return value.asString();
+        }
+    }
+
+    /**
+     * Gets a list value as a string for display
+     */
+    static std::string getListValueString(Value value) {
+        if (value.isUndefined()) {
+            return ""; // Scratch crashes, TurboWarp shows empty string
+        } else {
+            return value.asString();
+        }
+    }
+
+    /**
      * Gets the color for a monitor value background based on opcode
      */
     static ColorRGBA getMonitorValueColor(const std::string &opcode) {
@@ -300,7 +324,7 @@ class Render {
                             drawBox(monitorW - (24 * scale), boxHeight, monitorX + (22 * scale) + (monitorW - (28 * scale)) / 2, monitorY + boxHeight + item_y + (boxHeight / 2), 252, 102, 44);
 
                             std::unique_ptr<TextObject> &itemText = monitorGfx.items[index];
-                            itemText->setText(s.asString());
+                            itemText->setText(getListValueString(s));
                             itemText->setColor(Math::color(255, 255, 255, 255));
                             itemText->setScale(1.0f * (scale / 2.0f));
                             itemText->setCenterAligned(false);
@@ -394,7 +418,7 @@ class Render {
                     }
 
                 } else {
-                    std::string renderText = var.value.asString();
+                    std::string renderText = getVariableValueString(var.value);
                     if (monitorTexts.find(var.id) == monitorTexts.end()) {
                         monitorTexts[var.id].first = createTextObject(var.displayName.empty() ? " " : var.displayName, var.x, var.y);
                         monitorTexts[var.id].second = createTextObject(renderText.empty() ? " " : renderText, var.x, var.y);

--- a/source/runtime/blocks/motion.cpp
+++ b/source/runtime/blocks/motion.cpp
@@ -310,3 +310,11 @@ SCRATCH_REPORTER_BLOCK(motion, yposition) {
 SCRATCH_REPORTER_BLOCK(motion, direction) {
     return Value(sprite->rotation);
 }
+
+SCRATCH_REPORTER_BLOCK(motion, xscroll) {
+    return Value(Undefined{});
+}
+
+SCRATCH_REPORTER_BLOCK(motion, yscroll) {
+    return Value(Undefined{});
+}

--- a/source/runtime/blocks/sensing.cpp
+++ b/source/runtime/blocks/sensing.cpp
@@ -162,3 +162,7 @@ SCRATCH_REPORTER_BLOCK(sensing, username) {
 SCRATCH_REPORTER_BLOCK(sensing, online) {
     return Value(OS::isOnline());
 }
+
+SCRATCH_REPORTER_BLOCK(sensing, userid) {
+    return Value(Undefined{});
+}

--- a/source/runtime/value.cpp
+++ b/source/runtime/value.cpp
@@ -12,6 +12,8 @@ Value::Value(std::string val) : value(std::move(val)) {}
 
 Value::Value(bool val) : value(val) {}
 
+Value::Value(Undefined val) : value(val) {}
+
 double Value::asDouble() const {
     if (isDouble()) {
         if (isNaN()) return 0.0;
@@ -40,6 +42,8 @@ std::string Value::asString() const {
         return std::get<std::string>(value);
     } else if (isBoolean()) {
         return std::get<bool>(value) ? "true" : "false";
+    } else if (isUndefined()) {
+        return "undefined";
     } else if (isColor()) {
         const ColorRGBA rgb = CSBT2RGBA(std::get<Color>(value));
         const char hex_chars[] = "0123456789abcdef";

--- a/source/runtime/value.hpp
+++ b/source/runtime/value.hpp
@@ -6,9 +6,11 @@
 
 #include <variant>
 
+struct Undefined {};
+
 class Value {
   private:
-    std::variant<double, std::string, bool, Color> value;
+    std::variant<double, std::string, bool, Color, Undefined> value;
 
   public:
     // constructors
@@ -19,6 +21,7 @@ class Value {
     explicit Value(std::string val);
     explicit Value(bool val);
     explicit Value(Color val);
+    explicit Value(Undefined val);
 
     // type checks
     inline bool isDouble() const {
@@ -32,6 +35,9 @@ class Value {
     }
     inline bool isColor() const {
         return std::holds_alternative<Color>(value);
+    }
+    inline bool isUndefined() const {
+        return std::holds_alternative<Undefined>(value);
     }
     inline bool isNumeric() const {
         if (isDouble() || isBoolean()) {


### PR DESCRIPTION
Hello! This is just a minor change. It adds the hidden no-op reporter blocks mentioned in #396 that report the JavaScript value `undefined`, which has been added as its own type. It's doubtful anyone uses these blocks in this way, but supporting them further improves parity with Scratch. This also fixes the way some values are displayed in data monitors.

- Undefined has been added to Value as its own type. (If focusing only on Scratch blocks, reporting the string "undefined" would technically work, but in the future there may be some way of differentiating undefined from strings that would make this separate type necessary. Some custom extensions would also need this value as a separate type, e.g. `type of ()` in the TW Cast extension reports "undefined" when specifically given `undefined`.)
- The blocks `motion_xscroll`, `motion_yscroll`, and `sensing_userid` all report undefined.
- Scratch will crash when undefined is added to a list monitor, while TurboWarp will display nothing. When you set a variable monitor to undefined on either platform, it will not update until it is set to a value other than undefined. Adding this behavior would be kind of annoying due to the way SE! monitors work, so for now all monitors will show nothing when displaying undefined. While adding this I noticed numbers in variable monitors were not being truncated to six decimal places like in Scratch, so this has been fixed (this is done specifically for variable monitors, as list monitors keep the full number).

I haven't used C++ or contributed code here before, but the changes were relatively small and could be inferred from existing code. There might be a better way to truncate numbers to six decimal places, but besides that, I hope everything looks good!

[Test Project](https://github.com/user-attachments/files/25459984/Test.Project.zip) • [Live Version](https://oceanisendless.github.io/Scratch-Everywhere/?project_url=oceanisendless.github.io/hmm.sb3)