### PR TITLE
[SDL2/SDL3] Add Fast Pen project setting

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -271,6 +271,10 @@ elseif(SE_RENDERER STREQUAL "sdl2")
 	if(SE_SYSTEM)
 		pkg_check_modules(SDL2 REQUIRED sdl2>=2.0.0)
 		pkg_check_modules(SDL2_TTF REQUIRED SDL2_ttf>=2.0.0)
+
+		if(NOT WEBOS)
+			pkg_check_modules(SDL2_GFX REQUIRED SDL2_gfx>=1.0.0)
+		endif()
 	else()
 		if(CMAKE_SYSTEM_NAME STREQUAL "Darwin" AND CMAKE_CROSSCOMPILING)
 			message(STATUS "Test!")
@@ -295,10 +299,40 @@ elseif(SE_RENDERER STREQUAL "sdl2")
 			OPTIONS "SDL2TTF_VENDORED ON"
 		)
 	endif()
+
+	if(NOT SE_SYSTEM OR WEBOS)
+		CPMAddPackage(
+			NAME SDL2_gfx
+			VERSION 1.0.4
+			GITHUB_REPOSITORY giroletm/SDL2_gfx
+			GIT_TAG release-1.0.4
+			DOWNLOAD_ONLY TRUE # SDL2_gfx doesn't have a CMakeLists.txt
+		)
+		file(GLOB SDL2_GFX_SOURCES
+			"${SDL2_gfx_SOURCE_DIR}/SDL2_rotozoom.c"
+			"${SDL2_gfx_SOURCE_DIR}/SDL2_framerate.c"
+			"${SDL2_gfx_SOURCE_DIR}/SDL2_imageFilter.c"
+			"${SDL2_gfx_SOURCE_DIR}/SDL2_gfxPrimitives.c"
+			"${SDL2_gfx_SOURCE_DIR}/SDL2_bgi.c"
+		)
+		add_library(SDL2_gfx STATIC ${SDL2_GFX_SOURCES})
+		target_include_directories(SDL2_gfx PUBLIC
+			$<BUILD_INTERFACE:${SDL2_gfx_SOURCE_DIR}>
+		)
+		if(WEBOS)
+			target_link_libraries(SDL2_gfx PUBLIC ${SDL2_LIBRARIES})
+			target_include_directories(SDL2_gfx PRIVATE ${SDL2_INCLUDE_DIRS})
+		else()
+			target_link_libraries(SDL2_gfx PUBLIC
+				SDL2::SDL2
+			)
+		endif()
+	endif()
 elseif(SE_RENDERER STREQUAL "sdl3")
 	if(SE_SYSTEM)
 		pkg_check_modules(SDL3 REQUIRED sdl3>=3.0.0)
 		pkg_check_modules(SDL3_TTF REQUIRED sdl3-ttf>=3.0.0)
+		pkg_check_modules(SDL3_GFX REQUIRED sdl3-gfx>=1.0.0)
 	else()
 		CPMAddPackage(
 			NAME SDL3
@@ -313,6 +347,11 @@ elseif(SE_RENDERER STREQUAL "sdl3")
 			GITHUB_REPOSITORY libsdl-org/SDL_ttf
 			GIT_TAG release-3.2.2
 			OPTIONS "SDLTTF_VENDORED ON"
+		)
+		CPMAddPackage(
+			NAME SDL3_gfx
+			VERSION 1.0.1
+			GITHUB_REPOSITORY sabdul-khabir/SDL3_gfx
 		)
 	endif()
 elseif(SE_RENDERER STREQUAL "opengl")
@@ -558,22 +597,33 @@ if(SE_RENDERER STREQUAL "sdl3")
 
 	if(NOT SE_SYSTEM)
 		list(APPEND SDL_LINK_LIBS SDL3::SDL3)
+		target_include_directories(scratch-everywhere PRIVATE ${SDL3_gfx_SOURCE_DIR})
 	endif()
 
 	if(SE_SYSTEM)
-		list(APPEND SDL_LINK_LIBS ${SDL3_LIBRARIES} ${SDL3_TTF_LIBRARIES})
-		target_include_directories(scratch-everywhere PRIVATE ${SDL3_INCLUDE_DIRS} ${SDL3_TTF_INCLUDE_DIRS})
+		list(APPEND SDL_LINK_LIBS ${SDL3_LIBRARIES} ${SDL3_TTF_LIBRARIES} ${SDL3_GFX_LIBRARIES})
+		target_include_directories(scratch-everywhere PRIVATE ${SDL3_INCLUDE_DIRS} ${SDL3_TTF_INCLUDE_DIRS} ${SDL3_GFX_INCLUDE_DIRS})
 	elseif(BUILD_SHARED_LIBS)
 		list(APPEND SDL_LINK_LIBS SDL3_ttf::SDL3_ttf)
+		list(APPEND SDL_LINK_LIBS SDL3_gfx_Shared)
 	else()
 		list(APPEND SDL_LINK_LIBS $<IF:$<TARGET_EXISTS:SDL3_ttf::SDL3_ttf-static>,
 			SDL3_ttf::SDL3_ttf-static,
 			SDL3_ttf::SDL3_ttf>)
+		list(APPEND SDL_LINK_LIBS SDL3_gfx_Static)
 	endif()
 
 	target_link_libraries(scratch-everywhere PRIVATE ${SDL_LINK_LIBS})
 elseif(SE_RENDERER STREQUAL "sdl2")
 	set(SDL_LINK_LIBS)
+
+	if(SE_SYSTEM AND NOT WEBOS)
+		list(APPEND SDL_LINK_LIBS ${SDL2_GFX_LIBRARIES})
+		target_include_directories(scratch-everywhere PRIVATE ${SDL2_GFX_INCLUDE_DIRS})
+		target_link_directories(scratch-everywhere PRIVATE ${SDL2_GFX_LIBRARY_DIRS})
+	else()
+		list(APPEND SDL_LINK_LIBS SDL2_gfx)
+	endif()
 
 	if (NOT SE_SYSTEM)
 		list(APPEND SDL_LINK_LIBS SDL2::SDL2)
@@ -582,7 +632,6 @@ elseif(SE_RENDERER STREQUAL "sdl2")
 	if(SE_SYSTEM)
 		list(APPEND SDL_LINK_LIBS ${SDL2_LIBRARIES} ${SDL2_TTF_LIBRARIES})
 		target_include_directories(scratch-everywhere PRIVATE ${SDL2_INCLUDE_DIRS} ${SDL2_TTF_INCLUDE_DIRS})
-		target_link_directories(scratch-everywhere PRIVATE ${SDL2_LIBRARY_DIRS}${SDL2_TTF_LIBRARY_DIRS})
 
 	elseif(BUILD_SHARED_LIBS)
 		list(APPEND SDL_LINK_LIBS SDL2_ttf::SDL2_ttf)

--- a/source/menus/projectSettings.cpp
+++ b/source/menus/projectSettings.cpp
@@ -17,19 +17,23 @@ ProjectSettings::~ProjectSettings() {
 void ProjectSettings::init() {
     // initialize
 
-    changeControlsButton = new ButtonObject("Change Controls", "gfx/menu/projectBox.svg", 200, 80, "gfx/menu/Ubuntu-Bold");
+    changeControlsButton = new ButtonObject("Change Controls", "gfx/menu/projectBox.svg", 200, 50, "gfx/menu/Ubuntu-Bold");
     changeControlsButton->text->setColor(Math::color(0, 0, 0, 255));
     if (canUnpacked) {
-        UnpackProjectButton = new ButtonObject("Unpack Project", "gfx/menu/projectBox.svg", 200, 130, "gfx/menu/Ubuntu-Bold");
+        UnpackProjectButton = new ButtonObject("Unpack Project", "gfx/menu/projectBox.svg", 200, 100, "gfx/menu/Ubuntu-Bold");
         UnpackProjectButton->text->setColor(Math::color(0, 0, 0, 255));
     } else {
-        UnpackProjectButton = new ButtonObject("Delete Unpacked Project", "gfx/menu/projectBox.svg", 200, 130, "gfx/menu/Ubuntu-Bold");
+        UnpackProjectButton = new ButtonObject("Delete Unpacked Project", "gfx/menu/projectBox.svg", 200, 100, "gfx/menu/Ubuntu-Bold");
         UnpackProjectButton->text->setColor(Math::color(255, 0, 0, 255));
         UnpackProjectButton->text->setScale(0.75);
     }
-    bottomScreenButton = new ButtonObject("Bottom Screen", "gfx/menu/projectBox.svg", 200, 180, "gfx/menu/Ubuntu-Bold");
+    bottomScreenButton = new ButtonObject("Bottom Screen", "gfx/menu/projectBox.svg", 200, 150, "gfx/menu/Ubuntu-Bold");
     bottomScreenButton->text->setColor(Math::color(0, 0, 0, 255));
     bottomScreenButton->text->setScale(0.5);
+
+    penModeButton = new ButtonObject("Pen Mode: clicktoload", "gfx/menu/projectBox.svg", 200, 200, "gfx/menu/Ubuntu-Bold");
+    penModeButton->text->setColor(Math::color(0, 0, 0, 255));
+    penModeButton->text->setScale(0.5);
 
     settingsControl = new ControlObject();
     backButton = new ButtonObject("", "gfx/menu/buttonBack.svg", 375, 20, "gfx/menu/Ubuntu-Bold");
@@ -45,19 +49,28 @@ void ProjectSettings::init() {
     changeControlsButton->buttonUp = UnpackProjectButton;
     UnpackProjectButton->buttonUp = changeControlsButton;
     UnpackProjectButton->buttonDown = bottomScreenButton;
-    bottomScreenButton->buttonDown = changeControlsButton;
+    bottomScreenButton->buttonDown = penModeButton;
     bottomScreenButton->buttonUp = UnpackProjectButton;
+    penModeButton->buttonDown = changeControlsButton;
+    penModeButton->buttonUp = bottomScreenButton;
 
     // add buttons to control
     settingsControl->buttonObjects.push_back(changeControlsButton);
     settingsControl->buttonObjects.push_back(UnpackProjectButton);
     settingsControl->buttonObjects.push_back(bottomScreenButton);
+    settingsControl->buttonObjects.push_back(penModeButton);
 
     nlohmann::json settings = SettingsManager::getProjectSettings(projectPath);
-    if (!settings.is_null() && !settings["settings"].is_null() && settings["settings"]["bottomScreen"].get<bool>()) {
+    if (!settings.is_null() && !settings["settings"].is_null() && !settings["settings"]["bottomScreen"].is_null() && settings["settings"]["bottomScreen"].get<bool>()) {
         bottomScreenButton->text->setText("Bottom Screen: ON");
     } else {
         bottomScreenButton->text->setText("Bottom Screen: OFF");
+    }
+
+    if (!settings.is_null() && !settings["settings"].is_null() && !settings["settings"]["accuratePen"].is_null() && settings["settings"]["accuratePen"].get<bool>()) {
+        penModeButton->text->setText("Pen Mode: Accurate");
+    } else {
+        penModeButton->text->setText("Pen Mode: Fast");
     }
 
     isInitialized = true;
@@ -77,6 +90,12 @@ void ProjectSettings::render() {
         settings["settings"]["bottomScreen"] = bottomScreenButton->text->getText() == "Bottom Screen: ON" ? false : true;
         SettingsManager::saveProjectSettings(settings, projectPath);
         bottomScreenButton->text->setText(bottomScreenButton->text->getText() == "Bottom Screen: ON" ? "Bottom Screen: OFF" : "Bottom Screen: ON");
+    }
+    if (penModeButton->isPressed()) {
+        nlohmann::json settings = SettingsManager::getProjectSettings(projectPath);
+        settings["settings"]["accuratePen"] = penModeButton->text->getText() == "Pen Mode: Accurate" ? false : true;
+        SettingsManager::saveProjectSettings(settings, projectPath);
+        penModeButton->text->setText(penModeButton->text->getText() == "Pen Mode: Accurate" ? "Pen Mode: Fast" : "Pen Mode: Accurate");
     }
     if (UnpackProjectButton->isPressed({"a"})) {
         cleanup();
@@ -138,6 +157,10 @@ void ProjectSettings::cleanup() {
     if (backButton != nullptr) {
         delete backButton;
         backButton = nullptr;
+    }
+    if (penModeButton != nullptr) {
+        delete penModeButton;
+        penModeButton = nullptr;
     }
     // Render::beginFrame(0, 147, 138, 168);
     // Render::beginFrame(1, 147, 138, 168);

--- a/source/menus/projectSettings.hpp
+++ b/source/menus/projectSettings.hpp
@@ -9,6 +9,7 @@ class ProjectSettings : public Menu {
     ButtonObject *changeControlsButton = nullptr;
     ButtonObject *UnpackProjectButton = nullptr;
     ButtonObject *bottomScreenButton = nullptr;
+    ButtonObject *penModeButton = nullptr;
 
     bool canUnpacked = true;
     bool shouldGoBack = false;

--- a/source/renderers/citro2d/render.cpp
+++ b/source/renderers/citro2d/render.cpp
@@ -127,8 +127,18 @@ bool Render::initPen() {
     return true;
 }
 
-void Render::penMove(double x1, double y1, double x2, double y2, Sprite *sprite) {
+void Render::penMoveFast(double x1, double y1, double x2, double y2, Sprite *sprite) {
+    penMoveAccurate(x1, y1, x2, y2, sprite);
+}
+
+void Render::penDotFast(Sprite *sprite) {
+    penDotAccurate(sprite);
+}
+
+void Render::penMoveAccurate(double x1, double y1, double x2, double y2, Sprite *sprite) {
     const ColorRGBA rgbColor = CSBT2RGBA(sprite->penData.color);
+    uint8_t alpha = static_cast<uint8_t>((100.0 - sprite->penData.color.transparency) / 100.0 * 255.0);
+
     if (!Render::hasFrameBegan) {
         if (!C3D_FrameBegin(C3D_FRAME_NONBLOCK)) C3D_FrameBegin(C3D_FRAME_SYNCDRAW);
         Render::hasFrameBegan = true;
@@ -142,7 +152,7 @@ void Render::penMove(double x1, double y1, double x2, double y2, Sprite *sprite)
     const int PEN_Y_OFFSET = renderMode != BOTH_SCREENS ? 16 : (screenHeight * 0.5) + 32;
 
     const float heightMultiplier = 0.5f;
-    const u32 color = C2D_Color32(rgbColor.r, rgbColor.g, rgbColor.b, 255);
+    const u32 color = C2D_Color32(rgbColor.r, rgbColor.g, rgbColor.b, alpha);
     const float thickness = sprite->penData.size * renderScale;
 
     const float x1_scaled = (x1 * renderScale) + (width / 2);
@@ -162,7 +172,7 @@ void Render::penMove(double x1, double y1, double x2, double y2, Sprite *sprite)
     C2D_DrawCircleSolid(x2_scaled, y2_scaled, 0, radius, color);
 }
 
-void Render::penDot(Sprite *sprite) {
+void Render::penDotAccurate(Sprite *sprite) {
     const ColorRGBA rgbColor = CSBT2RGBA(sprite->penData.color);
     if (!Render::hasFrameBegan) {
         if (!C3D_FrameBegin(C3D_FRAME_NONBLOCK)) C3D_FrameBegin(C3D_FRAME_SYNCDRAW);

--- a/source/renderers/gl2d/render.cpp
+++ b/source/renderers/gl2d/render.cpp
@@ -92,10 +92,16 @@ bool Render::initPen() {
     return false;
 }
 
-void Render::penMove(double x1, double y1, double x2, double y2, Sprite *sprite) {
+void Render::penMoveAccurate(double x1, double y1, double x2, double y2, Sprite *sprite) {
 }
 
-void Render::penDot(Sprite *sprite) {
+void Render::penDotAccurate(Sprite *sprite) {
+}
+
+void Render::penMoveFast(double x1, double y1, double x2, double y2, Sprite *sprite) {
+}
+
+void Render::penDotFast(Sprite *sprite) {
 }
 
 void Render::penStamp(Sprite *sprite) {

--- a/source/renderers/headless/render.cpp
+++ b/source/renderers/headless/render.cpp
@@ -46,10 +46,16 @@ bool Render::initPen() {
     return false;
 }
 
-void Render::penMove(double x1, double y1, double x2, double y2, Sprite *sprite) {
+void Render::penMoveFast(double x1, double y1, double x2, double y2, Sprite *sprite) {
 }
 
-void Render::penDot(Sprite *sprite) {
+void Render::penDotFast(Sprite *sprite) {
+}
+
+void Render::penMoveAccurate(double x1, double y1, double x2, double y2, Sprite *sprite) {
+}
+
+void Render::penDotAccurate(Sprite *sprite) {
 }
 
 void Render::penStamp(Sprite *sprite) {

--- a/source/renderers/opengl/render.cpp
+++ b/source/renderers/opengl/render.cpp
@@ -223,7 +223,15 @@ static void finishPenDrawing() {
     glPopAttrib();
 }
 
-void Render::penMove(double x1, double y1, double x2, double y2, Sprite *sprite) {
+void Render::penMoveFast(double x1, double y1, double x2, double y2, Sprite *sprite) {
+    penMoveAccurate(x1, y1, x2, y2, sprite);
+}
+
+void Render::penDotFast(Sprite *sprite) {
+    penDotAccurate(sprite);
+}
+
+void Render::penMoveAccurate(double x1, double y1, double x2, double y2, Sprite *sprite) {
     const ColorRGBA rgbColor = CSBT2RGBA(sprite->penData.color);
     uint8_t alpha = (uint8_t)((100.0f - sprite->penData.color.transparency) / 100.0f * 255.0f);
 
@@ -264,7 +272,7 @@ void Render::penMove(double x1, double y1, double x2, double y2, Sprite *sprite)
     finishPenDrawing();
 }
 
-void Render::penDot(Sprite *sprite) {
+void Render::penDotAccurate(Sprite *sprite) {
     const ColorRGBA rgbColor = CSBT2RGBA(sprite->penData.color);
     uint8_t alpha = (uint8_t)((100.0f - sprite->penData.color.transparency) / 100.0f * 255.0f);
 

--- a/source/renderers/sdl1/render.cpp
+++ b/source/renderers/sdl1/render.cpp
@@ -107,7 +107,15 @@ bool Render::initPen() {
     return true;
 }
 
-void Render::penMove(double x1, double y1, double x2, double y2, Sprite *sprite) {
+void Render::penMoveFast(double x1, double y1, double x2, double y2, Sprite *sprite) {
+    penMoveAccurate(x1, y1, x2, y2, sprite);
+}
+
+void Render::penDotFast(Sprite *sprite) {
+    penDotAccurate(sprite);
+}
+
+void Render::penMoveAccurate(double x1, double y1, double x2, double y2, Sprite *sprite) {
     const ColorRGBA rgbColor = CSBT2RGBA(sprite->penData.color);
 
     int penWidth = penSurface->w;
@@ -149,7 +157,7 @@ void Render::penMove(double x1, double y1, double x2, double y2, Sprite *sprite)
     SDL_FreeSurface(tempSurface);
 }
 
-void Render::penDot(Sprite *sprite) {
+void Render::penDotAccurate(Sprite *sprite) {
     int penWidth = penSurface->w;
     int penHeight = penSurface->h;
 

--- a/source/renderers/sdl2/render.cpp
+++ b/source/renderers/sdl2/render.cpp
@@ -2,6 +2,7 @@
 #include "speech_manager_sdl2.hpp"
 #include "sprite.hpp"
 #include <SDL2/SDL.h>
+#include <SDL2_gfxPrimitives.h>
 #include <algorithm>
 #include <audio.hpp>
 #include <chrono>
@@ -278,6 +279,79 @@ void Render::penDotFast(Sprite *sprite) {
     penVerts.push_back(v1);
     penVerts.push_back(v3);
     penVerts.push_back(v2);
+}
+
+void Render::penMoveAccurate(double x1, double y1, double x2, double y2, Sprite *sprite) {
+    const ColorRGBA rgbColor = CSBT2RGBA(sprite->penData.color);
+
+    int penWidth = 640;
+    int penHeight = 480;
+    SDL_QueryTexture(penTexture, NULL, NULL, &penWidth, &penHeight);
+
+    SDL_Texture *tempTexture = SDL_CreateTexture(renderer, SDL_PIXELFORMAT_RGBA8888, SDL_TEXTUREACCESS_TARGET, penWidth, penHeight);
+    SDL_SetTextureBlendMode(tempTexture, SDL_BLENDMODE_BLEND);
+    SDL_SetTextureAlphaMod(tempTexture, (100 - sprite->penData.color.transparency) / 100.0f * 255);
+    SDL_SetRenderTarget(renderer, tempTexture);
+    SDL_SetRenderDrawColor(renderer, 0, 0, 0, 0);
+    SDL_RenderClear(renderer);
+
+    const double scale = (penHeight / static_cast<double>(Scratch::projectHeight));
+
+    const double dx = x2 * scale - x1 * scale;
+    const double dy = y2 * scale - y1 * scale;
+
+    const double length = sqrt(dx * dx + dy * dy);
+    const double drawWidth = (sprite->penData.size / 2.0f) * scale;
+
+    if (length > 0) {
+        const double nx = dx / length;
+        const double ny = dy / length;
+
+        int16_t vx[4], vy[4];
+        vx[0] = static_cast<int16_t>(x1 * scale + penWidth / 2.0f - ny * drawWidth);
+        vy[0] = static_cast<int16_t>(-y1 * scale + penHeight / 2.0f + nx * drawWidth);
+        vx[1] = static_cast<int16_t>(x1 * scale + penWidth / 2.0f + ny * drawWidth);
+        vy[1] = static_cast<int16_t>(-y1 * scale + penHeight / 2.0f - nx * drawWidth);
+        vx[2] = static_cast<int16_t>(x2 * scale + penWidth / 2.0f + ny * drawWidth);
+        vy[2] = static_cast<int16_t>(-y2 * scale + penHeight / 2.0f - nx * drawWidth);
+        vx[3] = static_cast<int16_t>(x2 * scale + penWidth / 2.0 - ny * drawWidth);
+        vy[3] = static_cast<int16_t>(-y2 * scale + penHeight / 2.0f + nx * drawWidth);
+
+        filledPolygonRGBA(renderer, vx, vy, 4, rgbColor.r, rgbColor.g, rgbColor.b, 255);
+    }
+
+    filledCircleRGBA(renderer, x1 * scale + penWidth / 2.0f, -y1 * scale + penHeight / 2.0f, drawWidth, rgbColor.r, rgbColor.g, rgbColor.b, 255);
+    filledCircleRGBA(renderer, x2 * scale + penWidth / 2.0f, -y2 * scale + penHeight / 2.0f, drawWidth, rgbColor.r, rgbColor.g, rgbColor.b, 255);
+
+    SDL_SetRenderTarget(renderer, penTexture);
+    SDL_SetRenderDrawBlendMode(renderer, SDL_BLENDMODE_BLEND);
+    SDL_RenderCopy(renderer, tempTexture, NULL, NULL);
+    SDL_SetRenderDrawBlendMode(renderer, SDL_BLENDMODE_BLEND);
+    SDL_SetRenderTarget(renderer, nullptr);
+    SDL_DestroyTexture(tempTexture);
+}
+
+void Render::penDotAccurate(Sprite *sprite) {
+    int penWidth;
+    int penHeight;
+    SDL_QueryTexture(penTexture, NULL, NULL, &penWidth, &penHeight);
+
+    SDL_Texture *tempTexture = SDL_CreateTexture(renderer, SDL_PIXELFORMAT_RGBA8888, SDL_TEXTUREACCESS_TARGET, penWidth, penHeight);
+    SDL_SetTextureBlendMode(tempTexture, SDL_BLENDMODE_BLEND);
+    SDL_SetTextureAlphaMod(tempTexture, (100 - sprite->penData.color.transparency) / 100.0f * 255);
+    SDL_SetRenderTarget(renderer, tempTexture);
+    SDL_SetRenderDrawColor(renderer, 0, 0, 0, 0);
+    SDL_RenderClear(renderer);
+
+    const double scale = (penHeight / static_cast<double>(Scratch::projectHeight));
+
+    const ColorRGBA rgbColor = CSBT2RGBA(sprite->penData.color);
+    filledCircleRGBA(renderer, sprite->xPosition * scale + penWidth / 2.0f, -sprite->yPosition * scale + penHeight / 2.0f, (sprite->penData.size / 2.0f) * scale, rgbColor.r, rgbColor.g, rgbColor.b, 255);
+
+    SDL_SetRenderTarget(renderer, penTexture);
+    SDL_RenderCopy(renderer, tempTexture, NULL, NULL);
+    SDL_SetRenderTarget(renderer, nullptr);
+    SDL_DestroyTexture(tempTexture);
 }
 
 void Render::penStamp(Sprite *sprite) {

--- a/source/renderers/sdl3/render.cpp
+++ b/source/renderers/sdl3/render.cpp
@@ -21,6 +21,12 @@
 #include <window.hpp>
 #include <windowing/sdl3/window.hpp>
 
+#ifdef SYSTEM_LIBS
+#include <SDL3_gfx/SDL3_gfxPrimitives.h>
+#else
+#include <SDL3_gfxPrimitives.h>
+#endif
+
 #ifdef __SWITCH__
 #include <switch.h>
 
@@ -140,74 +146,74 @@ bool Render::initPen() {
     return true;
 }
 
-// void Render::penMove(double x1, double y1, double x2, double y2, Sprite *sprite) {
-//     const ColorRGBA rgbColor = CSBT2RGBA(sprite->penData.color);
+void Render::penMoveAccurate(double x1, double y1, double x2, double y2, Sprite *sprite) {
+    const ColorRGBA rgbColor = CSBT2RGBA(sprite->penData.color);
 
-//     SDL_Texture *tempTexture = SDL_CreateTexture(renderer, SDL_PIXELFORMAT_RGBA8888, SDL_TEXTUREACCESS_TARGET, penTexture->w, penTexture->h);
-//     SDL_SetTextureBlendMode(tempTexture, SDL_BLENDMODE_BLEND);
-//     SDL_SetTextureScaleMode(tempTexture, SDL_SCALEMODE_NEAREST);
-//     SDL_SetTextureAlphaMod(tempTexture, (100 - sprite->penData.color.transparency) / 100.0f * 255);
-//     SDL_SetRenderTarget(renderer, tempTexture);
-//     SDL_SetRenderDrawColor(renderer, 0, 0, 0, 0);
-//     SDL_RenderClear(renderer);
+    SDL_Texture *tempTexture = SDL_CreateTexture(renderer, SDL_PIXELFORMAT_RGBA8888, SDL_TEXTUREACCESS_TARGET, penTexture->w, penTexture->h);
+    SDL_SetTextureBlendMode(tempTexture, SDL_BLENDMODE_BLEND);
+    SDL_SetTextureScaleMode(tempTexture, SDL_SCALEMODE_NEAREST);
+    SDL_SetTextureAlphaMod(tempTexture, (100 - sprite->penData.color.transparency) / 100.0f * 255);
+    SDL_SetRenderTarget(renderer, tempTexture);
+    SDL_SetRenderDrawColor(renderer, 0, 0, 0, 0);
+    SDL_RenderClear(renderer);
 
-//     const double scale = (penTexture->h / static_cast<double>(Scratch::projectHeight));
+    const double scale = (penTexture->h / static_cast<double>(Scratch::projectHeight));
 
-//     const double dx = x2 * scale - x1 * scale;
-//     const double dy = y2 * scale - y1 * scale;
+    const double dx = x2 * scale - x1 * scale;
+    const double dy = y2 * scale - y1 * scale;
 
-//     const double length = sqrt(dx * dx + dy * dy);
-//     const double drawWidth = (sprite->penData.size / 2.0f) * scale;
+    const double length = sqrt(dx * dx + dy * dy);
+    const double drawWidth = (sprite->penData.size / 2.0f) * scale;
 
-//     if (length > 0) {
-//         const double nx = dx / length;
-//         const double ny = dy / length;
+    if (length > 0) {
+        const double nx = dx / length;
+        const double ny = dy / length;
 
-//         int16_t vx[4], vy[4];
-//         vx[0] = static_cast<int16_t>(x1 * scale + penTexture->w / 2.0f - ny * drawWidth);
-//         vy[0] = static_cast<int16_t>(-y1 * scale + penTexture->h / 2.0f + nx * drawWidth);
-//         vx[1] = static_cast<int16_t>(x1 * scale + penTexture->w / 2.0f + ny * drawWidth);
-//         vy[1] = static_cast<int16_t>(-y1 * scale + penTexture->h / 2.0f - nx * drawWidth);
-//         vx[2] = static_cast<int16_t>(x2 * scale + penTexture->w / 2.0f + ny * drawWidth);
-//         vy[2] = static_cast<int16_t>(-y2 * scale + penTexture->h / 2.0f - nx * drawWidth);
-//         vx[3] = static_cast<int16_t>(x2 * scale + penTexture->w / 2.0 - ny * drawWidth);
-//         vy[3] = static_cast<int16_t>(-y2 * scale + penTexture->h / 2.0f + nx * drawWidth);
+        int16_t vx[4], vy[4];
+        vx[0] = static_cast<int16_t>(x1 * scale + penTexture->w / 2.0f - ny * drawWidth);
+        vy[0] = static_cast<int16_t>(-y1 * scale + penTexture->h / 2.0f + nx * drawWidth);
+        vx[1] = static_cast<int16_t>(x1 * scale + penTexture->w / 2.0f + ny * drawWidth);
+        vy[1] = static_cast<int16_t>(-y1 * scale + penTexture->h / 2.0f - nx * drawWidth);
+        vx[2] = static_cast<int16_t>(x2 * scale + penTexture->w / 2.0f + ny * drawWidth);
+        vy[2] = static_cast<int16_t>(-y2 * scale + penTexture->h / 2.0f - nx * drawWidth);
+        vx[3] = static_cast<int16_t>(x2 * scale + penTexture->w / 2.0 - ny * drawWidth);
+        vy[3] = static_cast<int16_t>(-y2 * scale + penTexture->h / 2.0f + nx * drawWidth);
 
-//         filledPolygonRGBA(renderer, vx, vy, 4, rgbColor.r, rgbColor.g, rgbColor.b, 255);
-//     }
+        filledPolygonRGBA(renderer, vx, vy, 4, rgbColor.r, rgbColor.g, rgbColor.b, 255);
+    }
 
-//     filledCircleRGBA(renderer, x1 * scale + penTexture->w / 2.0f, -y1 * scale + penTexture->h / 2.0f, drawWidth, rgbColor.r, rgbColor.g, rgbColor.b, 255);
-//     filledCircleRGBA(renderer, x2 * scale + penTexture->w / 2.0f, -y2 * scale + penTexture->h / 2.0f, drawWidth, rgbColor.r, rgbColor.g, rgbColor.b, 255);
+    filledCircleRGBA(renderer, x1 * scale + penTexture->w / 2.0f, -y1 * scale + penTexture->h / 2.0f, drawWidth, rgbColor.r, rgbColor.g, rgbColor.b, 255);
+    filledCircleRGBA(renderer, x2 * scale + penTexture->w / 2.0f, -y2 * scale + penTexture->h / 2.0f, drawWidth, rgbColor.r, rgbColor.g, rgbColor.b, 255);
 
-//     SDL_SetRenderTarget(renderer, penTexture);
-//     SDL_SetRenderDrawBlendMode(renderer, SDL_BLENDMODE_BLEND);
-//     SDL_RenderTexture(renderer, tempTexture, NULL, NULL);
-//     SDL_SetRenderDrawBlendMode(renderer, SDL_BLENDMODE_BLEND);
-//     SDL_SetRenderTarget(renderer, nullptr);
-//     SDL_DestroyTexture(tempTexture);
-// }
+    SDL_SetRenderTarget(renderer, penTexture);
+    SDL_SetRenderDrawBlendMode(renderer, SDL_BLENDMODE_BLEND);
+    SDL_RenderTexture(renderer, tempTexture, NULL, NULL);
+    SDL_SetRenderDrawBlendMode(renderer, SDL_BLENDMODE_BLEND);
+    SDL_SetRenderTarget(renderer, nullptr);
+    SDL_DestroyTexture(tempTexture);
+}
 
-// void Render::penDot(Sprite *sprite) {
-//     SDL_Texture *tempTexture = SDL_CreateTexture(renderer, SDL_PIXELFORMAT_RGBA8888, SDL_TEXTUREACCESS_TARGET, penTexture->w, penTexture->h);
-//     SDL_SetTextureBlendMode(tempTexture, SDL_BLENDMODE_BLEND);
-//     SDL_SetTextureScaleMode(tempTexture, SDL_SCALEMODE_NEAREST);
-//     SDL_SetTextureAlphaMod(tempTexture, (100 - sprite->penData.color.transparency) / 100.0f * 255);
-//     SDL_SetRenderTarget(renderer, tempTexture);
-//     SDL_SetRenderDrawColor(renderer, 0, 0, 0, 0);
-//     SDL_RenderClear(renderer);
+void Render::penDotAccurate(Sprite *sprite) {
+    SDL_Texture *tempTexture = SDL_CreateTexture(renderer, SDL_PIXELFORMAT_RGBA8888, SDL_TEXTUREACCESS_TARGET, penTexture->w, penTexture->h);
+    SDL_SetTextureBlendMode(tempTexture, SDL_BLENDMODE_BLEND);
+    SDL_SetTextureScaleMode(tempTexture, SDL_SCALEMODE_NEAREST);
+    SDL_SetTextureAlphaMod(tempTexture, (100 - sprite->penData.color.transparency) / 100.0f * 255);
+    SDL_SetRenderTarget(renderer, tempTexture);
+    SDL_SetRenderDrawColor(renderer, 0, 0, 0, 0);
+    SDL_RenderClear(renderer);
 
-//     const double scale = (penTexture->h / static_cast<double>(Scratch::projectHeight));
+    const double scale = (penTexture->h / static_cast<double>(Scratch::projectHeight));
 
-//     const ColorRGBA rgbColor = CSBT2RGBA(sprite->penData.color);
-//     filledCircleRGBA(renderer, sprite->xPosition * scale + penTexture->w / 2.0f, -sprite->yPosition * scale + penTexture->h / 2.0f, (sprite->penData.size / 2.0f) * scale, rgbColor.r, rgbColor.g, rgbColor.b, 255);
+    const ColorRGBA rgbColor = CSBT2RGBA(sprite->penData.color);
+    filledCircleRGBA(renderer, sprite->xPosition * scale + penTexture->w / 2.0f, -sprite->yPosition * scale + penTexture->h / 2.0f, (sprite->penData.size / 2.0f) * scale, rgbColor.r, rgbColor.g, rgbColor.b, 255);
 
-//     SDL_SetRenderTarget(renderer, penTexture);
-//     SDL_RenderTexture(renderer, tempTexture, NULL, NULL);
-//     SDL_SetRenderTarget(renderer, nullptr);
-//     SDL_DestroyTexture(tempTexture);
-// }
+    SDL_SetRenderTarget(renderer, penTexture);
+    SDL_RenderTexture(renderer, tempTexture, NULL, NULL);
+    SDL_SetRenderTarget(renderer, nullptr);
+    SDL_DestroyTexture(tempTexture);
+}
 
-void Render::penMove(double x1, double y1, double x2, double y2, Sprite *sprite) {
+void Render::penMoveFast(double x1, double y1, double x2, double y2, Sprite *sprite) {
     const ColorRGBA rgbColor = CSBT2RGBA(sprite->penData.color);
     float alpha = static_cast<Uint8>((100.0 - sprite->penData.color.transparency) / 100.0);
 
@@ -254,7 +260,7 @@ void Render::penMove(double x1, double y1, double x2, double y2, Sprite *sprite)
     }
 }
 
-void Render::penDot(Sprite *sprite) {
+void Render::penDotFast(Sprite *sprite) {
     const ColorRGBA rgbColor = CSBT2RGBA(sprite->penData.color);
     float alpha = static_cast<Uint8>((100.0 - sprite->penData.color.transparency) / 100.0);
 

--- a/source/runtime/blocks/pen.cpp
+++ b/source/runtime/blocks/pen.cpp
@@ -9,7 +9,9 @@ SCRATCH_BLOCK(pen, penDown) {
     if (!Render::initPen()) return BlockResult::CONTINUE;
     sprite->penData.down = true;
 
-    Render::penDot(sprite);
+    if (Scratch::accuratePen)
+        Render::penDotAccurate(sprite);
+    else Render::penDotFast(sprite);
 
     Scratch::forceRedraw = true;
     return BlockResult::CONTINUE;

--- a/source/runtime/parser.cpp
+++ b/source/runtime/parser.cpp
@@ -616,6 +616,11 @@ void Parser::loadSprites(const nlohmann::json &json) {
     Render::renderMode = Render::TOP_SCREEN_ONLY;
 #endif
 
+    auto accuratePen = Unzip::getSetting("accuratePen");
+    if (!accuratePen.is_null() && accuratePen.get<bool>())
+        Scratch::accuratePen = true;
+    else Scratch::accuratePen = false;
+
     if (infClones) Scratch::maxClones = std::numeric_limits<int>::max();
     else Scratch::maxClones = 300;
 

--- a/source/runtime/runtime.cpp
+++ b/source/runtime/runtime.cpp
@@ -48,6 +48,7 @@ bool Scratch::fencing = true;
 bool Scratch::miscellaneousLimits = true;
 bool Scratch::shouldStop = false;
 bool Scratch::forceRedraw = false;
+bool Scratch::accuratePen = false;
 
 double Scratch::counter = 0;
 
@@ -522,7 +523,10 @@ void Scratch::gotoXY(Sprite *sprite, double x, double y) {
 
     if (Scratch::fencing) fenceSpriteWithinBounds(sprite);
 
-    if (sprite->penData.down && (oldX != sprite->xPosition || oldY != sprite->yPosition)) Render::penMove(oldX, oldY, sprite->xPosition, sprite->yPosition, sprite);
+    if (sprite->penData.down && (oldX != sprite->xPosition || oldY != sprite->yPosition)) {
+        if (accuratePen) Render::penMoveAccurate(oldX, oldY, sprite->xPosition, sprite->yPosition, sprite);
+        else Render::penMoveFast(oldX, oldY, sprite->xPosition, sprite->yPosition, sprite);
+    }
     Scratch::forceRedraw = true;
 }
 

--- a/source/runtime/runtime.hpp
+++ b/source/runtime/runtime.hpp
@@ -81,6 +81,7 @@ class Scratch {
     static bool turbo;
     static bool fencing;
     static bool hqpen;
+    static bool accuratePen;
     static bool miscellaneousLimits;
     static bool shouldStop;
     static bool forceRedraw;


### PR DESCRIPTION
the fast pen option batches all the pen draws to be used in a single `SDL_RenderGeometry()` draw call. 

Fast:
<img width="539" height="399" alt="image" src="https://github.com/user-attachments/assets/4820151d-67df-405d-bd65-bc9eb5024fbf" />

Accurate (which is just the old code):
<img width="541" height="394" alt="image" src="https://github.com/user-attachments/assets/1f6264a7-98f5-4c88-be25-eeafd5787561" />

The reason why there's two options is because fast pen currently draws everything as rectangles, instead of it being rounded. The accurate option could also use SDL_RenderGeometry but im too lazy to figure out the math right now :grin: :v:

test project: 
[penny.sb3.zip](https://github.com/user-attachments/files/25525907/penny.sb3.zip)
