### PR TITLE
feat(translate): add extension and cache clearing

### DIFF
--- a/source/menus/settingsMenu.cpp
+++ b/source/menus/settingsMenu.cpp
@@ -152,9 +152,8 @@ void SettingsMenu::render() {
     Render::beginFrame(1, 96, 90, 105);
 
     if (ClearCache->isPressed({"a"})) {
-        // clear folder: OS::getScratchFolderLocation() + "cache/"
-        std::filesystem::remove_all(OS::getScratchFolderLocation() + "cache/");
-        std::filesystem::create_directory(OS::getScratchFolderLocation() + "cache/");
+        OS::removeDirectory(OS::getScratchFolderLocation() + "cache/");
+        OS::createDirectory(OS::getScratchFolderLocation() + "cache/");
     }
 
     if (EnableMenuMusic->isPressed({"a"})) {

--- a/source/menus/settingsMenu.cpp
+++ b/source/menus/settingsMenu.cpp
@@ -37,6 +37,10 @@ void SettingsMenu::init() {
     EnableMenuMusic->text->setColor(Math::color(0, 0, 0, 255));
     EnableMenuMusic->text->setScale(0.5);
 
+    ClearCache = new ButtonObject("Clear Cache", "gfx/menu/projectBox.svg", 200, 270, "gfx/menu/Ubuntu-Bold", true);
+    ClearCache->text->setColor(Math::color(0, 0, 0, 255));
+    ClearCache->text->setScale(0.5);
+
     // initial selected object
     settingsControl->selectedObject = EnableUsername;
     EnableUsername->isSelected = true;
@@ -81,6 +85,7 @@ void SettingsMenu::init() {
     settingsControl->buttonObjects.push_back(EnableCustomFolderPath);
     settingsControl->buttonObjects.push_back(ChangeUsername);
     settingsControl->buttonObjects.push_back(EnableUsername);
+    settingsControl->buttonObjects.push_back(ClearCache);
 
     settingsControl->enableScrolling = true;
     settingsControl->setScrollLimits();
@@ -93,8 +98,10 @@ void SettingsMenu::updateButtonStates() {
     ChangeUsername->buttonDown = EnableCustomFolderPath;
     ChangeFolderPath->buttonUp = EnableCustomFolderPath;
     ChangeFolderPath->buttonDown = EnableMenuMusic;
-    EnableUsername->buttonUp = EnableMenuMusic;
-    EnableMenuMusic->buttonDown = EnableUsername;
+    EnableUsername->buttonUp = ClearCache;
+    EnableMenuMusic->buttonDown = ClearCache;
+    ClearCache->buttonUp = EnableMenuMusic;
+    ClearCache->buttonDown = EnableUsername;
 
     if (UseCostumeUsername) {
         EnableUsername->text->setText("Username: Enabled");
@@ -143,6 +150,12 @@ void SettingsMenu::render() {
 
     Render::beginFrame(0, 96, 90, 105);
     Render::beginFrame(1, 96, 90, 105);
+
+    if (ClearCache->isPressed({"a"})) {
+        // clear folder: OS::getScratchFolderLocation() + "cache/"
+        std::filesystem::remove_all(OS::getScratchFolderLocation() + "cache/");
+        std::filesystem::create_directory(OS::getScratchFolderLocation() + "cache/");
+    }
 
     if (EnableMenuMusic->isPressed({"a"})) {
         menuMusic = !menuMusic;

--- a/source/menus/settingsMenu.hpp
+++ b/source/menus/settingsMenu.hpp
@@ -15,6 +15,7 @@ class SettingsMenu : public Menu {
     ButtonObject *EnableCustomFolderPath = nullptr;
     ButtonObject *ChangeFolderPath = nullptr;
     ButtonObject *EnableMenuMusic = nullptr;
+    ButtonObject *ClearCache = nullptr;
 
     bool UseCostumeUsername = false;
     std::string username;

--- a/source/runtime/blocks/translate.cpp
+++ b/source/runtime/blocks/translate.cpp
@@ -48,6 +48,7 @@ SCRATCH_BLOCK(translate, getTranslate) {
         std::string words = wordsInput.asString();
         if (std::all_of(words.begin(), words.end(), ::isdigit)) {
             *outValue = wordsInput;
+            thread->eraseState(block);
             return BlockResult::CONTINUE;
         }
 
@@ -73,6 +74,7 @@ SCRATCH_BLOCK(translate, getTranslate) {
                 start += 10;
                 size_t end = content.find("\"", start);
                 *outValue = Value(content.substr(start, end - start));
+                thread->eraseState(block);
                 return BlockResult::CONTINUE;
             }
         }

--- a/source/runtime/blocks/translate.cpp
+++ b/source/runtime/blocks/translate.cpp
@@ -1,3 +1,116 @@
 #include "blockUtils.hpp"
+#include "downloader.hpp"
+#include "math.hpp"
+#include "os.hpp"
+#include "runtime.hpp"
+#include "sprite.hpp"
+#include "unzip.hpp"
+#include "value.hpp"
+#include <algorithm>
+#include <string>
+#include <unordered_map>
+
+// We could retrieve that from the internet, but I don't know if that's a good idea and I also don't know which API we should use.
+std::unordered_map<std::string, std::string> locales = {
+    {"ab", "Аҧсшәа"}, {"af", "Afrikaans"}, {"ar", "العربية"}, {"am", "አማርኛ"}, {"an", "Aragonés"}, {"ast", "Asturianu"}, {"az", "Azeri"}, {"id", "Bahasa Indonesia"}, {"bn", "বাংলা"}, {"be", "Беларуская"}, {"bg", "Български"}, {"ca", "Català"}, {"cs", "Česky"}, {"cy", "Cymraeg"}, {"da", "Dansk"}, {"de", "Deutsch"}, {"et", "Eesti"}, {"el", "Ελληνικά"}, {"en", "English"}, {"es", "Español (España)"}, {"es-419", "Español Latinoamericano"}, {"eo", "Esperanto"}, {"eu", "Euskara"}, {"fa", "فارسی"}, {"fil", "Filipino"}, {"fr", "Français"}, {"fy", "Frysk"}, {"ga", "Gaeilge"}, {"gd", "Gàidhlig"}, {"gl", "Galego"}, {"ko", "한국어"}, {"ha", "Hausa"}, {"hy", "Հայերեն"}, {"he", "עִבְרִית"}, {"hi", "हिंदी"}, {"hr", "Hrvatski"}, {"xh", "isiXhosa"}, {"zu", "isiZulu"}, {"is", "Íslenska"}, {"it", "Italiano"}, {"ka", "ქართული ენა"}, {"kk", "қазақша"}, {"qu", "Kichwa"}, {"sw", "Kiswahili"}, {"ht", "Kreyòl ayisyen"}, {"ku", "Kurdî"}, {"ckb", "کوردیی ناوەندی"}, {"lv", "Latviešu"}, {"lt", "Lietuvių"}, {"hu", "Magyar"}, {"mi", "Māori"}, {"mn", "Монгол хэл"}, {"nl", "Nederlands"}, {"ja", "日本語"}, {"ja-Hira", "にほんご"}, {"nb", "Norsk Bokmål"}, {"nn", "Norsk Nynorsk"}, {"oc", "Occitan"}, {"or", "ଓଡ଼ିଆ"}, {"uz", "Oʻzbekcha"}, {"th", "ไทย"}, {"km", "ភាសាខ្មែរ"}, {"pl", "Polski"}, {"pt", "Português"}, {"pt-br", "Português Brasileiro"}, {"rap", "Rapa Nui"}, {"ro", "Română"}, {"ru", "Русский"}, {"nso", "Sepedi"}, {"tn", "Setswana"}, {"sk", "Slovenčina"}, {"sl", "Slovenščina"}, {"sr", "Српски"}, {"fi", "Suomi"}, {"sv", "Svenska"}, {"vi", "Tiếng Việt"}, {"tr", "Türkçe"}, {"uk", "Українська"}, {"zh-cn", "简体中文"}, {"zh-tw", "繁體中文"}};
+
+std::string getCodeFromArg(const std::string &arg) {
+    std::string lowerArg = arg;
+    std::transform(lowerArg.begin(), lowerArg.end(), lowerArg.begin(), ::tolower);
+
+    if (locales.find(lowerArg) != locales.end()) return lowerArg;
+
+    for (const auto &[code, name] : locales) {
+        std::string lowerName = name;
+        std::transform(lowerName.begin(), lowerName.end(), lowerName.begin(), ::tolower);
+        if (lowerName == lowerArg) return code;
+    }
+
+    return "en";
+}
+
+std::string getNameFromCode(const std::string &code) {
+    auto it = locales.find(code);
+    if (it != locales.end()) return it->second;
+    return "English";
+}
 
 SCRATCH_SHADOW_BLOCK(translate_menu_languages, languages)
+
+SCRATCH_BLOCK(translate, getTranslate) {
+#if defined(ENABLE_DOWNLOAD)
+    BlockState *state = thread->getState(block);
+    if (state->completedSteps == 0) {
+        Value wordsInput, languageInput;
+        if (!Scratch::getInput(block, "WORDS", thread, sprite, wordsInput) ||
+            !Scratch::getInput(block, "LANGUAGE", thread, sprite, languageInput)) return BlockResult::REPEAT;
+
+        std::string words = wordsInput.asString();
+        if (std::all_of(words.begin(), words.end(), ::isdigit)) {
+            *outValue = wordsInput;
+            return BlockResult::CONTINUE;
+        }
+
+        std::string langCode = getCodeFromArg(languageInput.asString());
+
+        state->name = "https://trampoline.turbowarp.org/translate/translate?language=" + langCode + "&text=" + urlEncode(words);
+        std::string tempDir = OS::getScratchFolderLocation() + "cache/";
+        std::size_t h = std::hash<std::string>{}(state->name);
+        std::string tempFile = tempDir + "translate_temp_" + std::to_string(h) + ".txt";
+
+        state->completedSteps = 1;
+
+        if (!DownloadManager::init()) return BlockResult::CONTINUE;
+
+        // Check cache
+        if (OS::fileExists(tempFile) && !DownloadManager::isDownloading(state->name)) {
+            std::ifstream file(tempFile);
+            std::string content((std::istreambuf_iterator<char>(file)), std::istreambuf_iterator<char>());
+            file.close();
+
+            size_t start = content.find("\"result\":\"");
+            if (start != std::string::npos) {
+                start += 10;
+                size_t end = content.find("\"", start);
+                *outValue = Value(content.substr(start, end - start));
+                return BlockResult::CONTINUE;
+            }
+        }
+
+        DownloadManager::addDownload(state->name, tempFile);
+        return BlockResult::REPEAT;
+    }
+
+    std::string tempDir = OS::getScratchFolderLocation() + "cache/";
+    std::size_t h = std::hash<std::string>{}(state->name);
+    std::string tempFile = tempDir + "translate_temp_" + std::to_string(h) + ".txt";
+
+    if (DownloadManager::isDownloading(state->name)) return BlockResult::REPEAT;
+
+    std::ifstream file(tempFile);
+    std::string content((std::istreambuf_iterator<char>(file)), std::istreambuf_iterator<char>());
+    file.close();
+
+    size_t start = content.find("\"result\":\"");
+    if (start != std::string::npos) {
+        start += 10;
+        size_t end = content.find("\"", start);
+        *outValue = Value(content.substr(start, end - start));
+    } else {
+        *outValue = Value("");
+    }
+
+    thread->eraseState(block);
+#else
+    *outValue = Value("");
+#endif
+    return BlockResult::CONTINUE;
+}
+
+SCRATCH_BLOCK(translate, getViewerLanguage) {
+    // Uses English by default,
+    // ToDo: but ready for i18n
+    std::string currentLocale = "en";
+    *outValue = Value(getNameFromCode(currentLocale));
+    return BlockResult::CONTINUE;
+}


### PR DESCRIPTION
I'm not entirely satisfied with the current handling of language codes. However, I'm not aware of any other solution that doesn't require parsing another JSON file at runtime or retrieving the language code from a server before translation.

The block works similarly to the Text2Speech block (except that the downloaded file is returned as a value and not played back)

I've also added a "Clear cache" button, as the folder can fill up quickly.
Perhaps an option to enable automatic cache clearing (when the app/project starts) could be added ?

(Tested on Linux)