### PR TITLE
fix(linux): correct category for desktop file

### DIFF
--- a/gfx/linux/scratch-everywhere.desktop
+++ b/gfx/linux/scratch-everywhere.desktop
@@ -10,5 +10,5 @@ Icon=scratch-everywhere
 Type=Application
 Terminal=false
 PrefersNonDefaultGPU=true
-Categories=Games
+Categories=Game
 MimeType=application/x.scratch.sb3;


### PR DESCRIPTION
Fixes SE! appearing in Lost & Found when installed via the AUR.